### PR TITLE
release: v0.1.0-dev.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Current
+## v0.1.0-dev.1.11
 
 ### core
 


### PR DESCRIPTION
Dev release for #11 (Session interface and in-memory implementation).

Converts CHANGELOG `## Current` to `## v0.1.0-dev.1.11` section. Tag will be created after merge.