### PR TITLE
Tool registry interface and execution

### DIFF
--- a/.claude/context/guides/.archive/12-tool-registry.md
+++ b/.claude/context/guides/.archive/12-tool-registry.md
@@ -1,0 +1,316 @@
+# 12 - Tool Registry Interface and Execution
+
+## Problem Context
+
+The tools subsystem needs a registry for tool handlers that maps LLM tool calls to their execution. Currently `agent.Tool` and `providers.ToolDefinition` are identical types in two packages. Adding a third in `tools` would create three-way duplication, violating the principle that exported data structures are the protocol — defined once, consumed directly at higher levels.
+
+The registry follows the global singleton catalog pattern established by `agent/providers/registry.go`. It catalogs all available tools — the kernel selects which subset to offer the LLM per turn. Built-in tools (future) self-register via `init()` in sub-packages; external libraries extend the catalog by calling `tools.Register()`.
+
+## Architecture Approach
+
+1. Define `protocol.Tool` in `core/protocol` as the canonical tool definition type
+2. Replace `agent.Tool` and `providers.ToolDefinition` with `protocol.Tool` throughout
+3. Build the global tool registry in `tools/` using `protocol.Tool`, following the providers registry pattern
+
+## Implementation
+
+### Step 1: Define `protocol.Tool` in core
+
+**New file: `core/protocol/tool.go`**
+
+```go
+package protocol
+
+// Tool defines a function that can be called by the LLM.
+type Tool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Parameters  map[string]any `json:"parameters"`
+}
+```
+
+### Step 2: Update `agent/providers/data.go`
+
+Remove the `ToolDefinition` struct and update `ToolsData` to use `protocol.Tool`:
+
+```go
+// ToolsData contains the data needed to marshal a tools request.
+type ToolsData struct {
+	Model    string
+	Messages []protocol.Message
+	Tools    []protocol.Tool
+	Options  map[string]any
+}
+```
+
+Remove lines 29-36 (`ToolDefinition` struct).
+
+### Step 3: Update `agent/request/tools.go`
+
+Replace `[]providers.ToolDefinition` with `[]protocol.Tool`. The `providers` import is still needed for `providers.Provider` and `providers.ToolsData`.
+
+```go
+type ToolsRequest struct {
+	messages []protocol.Message
+	tools    []protocol.Tool
+	options  map[string]any
+	provider providers.Provider
+	model    *model.Model
+}
+
+func NewTools(p providers.Provider, m *model.Model, messages []protocol.Message, tools []protocol.Tool, opts map[string]any) *ToolsRequest {
+	return &ToolsRequest{
+		messages: messages,
+		tools:    tools,
+		options:  opts,
+		provider: p,
+		model:    m,
+	}
+}
+```
+
+### Step 4: Update `agent/agent.go`
+
+Update the `Agent` interface method signature (line 61):
+
+```go
+Tools(ctx context.Context, prompt string, tools []protocol.Tool, opts ...map[string]any) (*response.ToolsResponse, error)
+```
+
+Update the implementation method (lines 216-247). Remove the conversion loop — pass `[]protocol.Tool` directly to the request:
+
+```go
+func (a *agent) Tools(ctx context.Context, prompt string, tools []protocol.Tool, opts ...map[string]any) (*response.ToolsResponse, error) {
+	messages := a.initMessages(prompt)
+	options := a.mergeOptions(protocol.Tools, opts...)
+
+	req := request.NewTools(a.provider, a.model, messages, tools, options)
+
+	result, err := a.client.Execute(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, ok := result.(*response.ToolsResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected response type: %T", result)
+	}
+
+	return resp, nil
+}
+```
+
+Remove the `Tool` struct at lines 327-340.
+
+### Step 5: Update `agent/mock/agent.go`
+
+Update the `Tools` method signature (line 202):
+
+```go
+func (m *MockAgent) Tools(ctx context.Context, prompt string, tools []protocol.Tool, opts ...map[string]any) (*response.ToolsResponse, error) {
+	return m.toolsResponse, m.toolsError
+}
+```
+
+The `agent` import can be removed since `MockAgent` no longer references `agent.Tool`. The interface assertion `var _ agent.Agent = (*MockAgent)(nil)` still needs the import.
+
+### Step 6: Update `cmd/prompt-agent/main.go`
+
+Update imports — replace `agent` with `protocol`:
+
+```go
+import (
+	// ...existing imports...
+	"github.com/tailored-agentic-units/kernel/agent"
+	"github.com/tailored-agentic-units/kernel/core/config"
+	"github.com/tailored-agentic-units/kernel/core/protocol"
+)
+```
+
+Update `executeTools` signature (line 159):
+
+```go
+func executeTools(ctx context.Context, agent agent.Agent, prompt string, tools []protocol.Tool) {
+```
+
+Update `loadTools` function (lines 266-278):
+
+```go
+func loadTools(filename string) []protocol.Tool {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		log.Fatalf("Failed to read tools file: %v", err)
+	}
+
+	var tools []protocol.Tool
+	if err := json.Unmarshal(data, &tools); err != nil {
+		log.Fatalf("Failed to parse tools file: %v", err)
+	}
+
+	return tools
+}
+```
+
+### Step 7: Update `agent/doc.go`
+
+Update the Tools Protocol section. Change `agent.Tool` references to `protocol.Tool`:
+
+Line 21: `Tools(ctx context.Context, prompt string, tools []protocol.Tool, opts ...map[string]any) (*types.ToolsResponse, error)`
+
+Line 123: `tools := []protocol.Tool{`
+
+Lines 213-221 (Tool Definitions section): Update the struct reference to show `protocol.Tool`.
+
+### Step 8: Update `_project/README.md` Known Gaps
+
+Replace lines 164-170:
+
+```markdown
+## Known Gaps
+
+One limitation identified in the current codebase, deferred to per-subsystem concept sessions:
+
+1. **Agent methods create fresh messages** — The `Agent` interface methods accept a `prompt string` and internally create a fresh message list. Incompatible with multi-turn conversations where full history must be passed. Deferred to agent subsystem redesign.
+```
+
+### Step 9: Create `tools/errors.go`
+
+**New file: `tools/errors.go`**
+
+```go
+package tools
+
+import "errors"
+
+var (
+	ErrNotFound      = errors.New("tool not found")
+	ErrAlreadyExists = errors.New("tool already registered")
+	ErrEmptyName     = errors.New("tool name is empty")
+)
+```
+
+### Step 10: Create `tools/registry.go`
+
+**New file: `tools/registry.go`**
+
+Follow the `agent/providers/registry.go` pattern exactly:
+
+```go
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/tailored-agentic-units/kernel/core/protocol"
+)
+
+type Handler func(ctx context.Context, args json.RawMessage) (Result, error)
+
+type Result struct {
+	Content string
+	IsError bool
+}
+
+type entry struct {
+	tool    protocol.Tool
+	handler Handler
+}
+
+type registry struct {
+	entries map[string]entry
+	mu      sync.RWMutex
+}
+
+var register = &registry{
+	entries: make(map[string]entry),
+}
+
+func Register(tool protocol.Tool, handler Handler) error {
+	if tool.Name == "" {
+		return ErrEmptyName
+	}
+
+	register.mu.Lock()
+	defer register.mu.Unlock()
+
+	if _, exists := register.entries[tool.Name]; exists {
+		return fmt.Errorf("%w: %s", ErrAlreadyExists, tool.Name)
+	}
+
+	register.entries[tool.Name] = entry{tool: tool, handler: handler}
+	return nil
+}
+
+func Replace(tool protocol.Tool, handler Handler) error {
+	if tool.Name == "" {
+		return ErrEmptyName
+	}
+
+	register.mu.Lock()
+	defer register.mu.Unlock()
+
+	if _, exists := register.entries[tool.Name]; !exists {
+		return fmt.Errorf("%w: %s", ErrNotFound, tool.Name)
+	}
+
+	register.entries[tool.Name] = entry{tool: tool, handler: handler}
+	return nil
+}
+
+func Get(name string) (Handler, bool) {
+	register.mu.RLock()
+	defer register.mu.RUnlock()
+
+	e, exists := register.entries[name]
+	if !exists {
+		return nil, false
+	}
+	return e.handler, true
+}
+
+func List() []protocol.Tool {
+	register.mu.RLock()
+	defer register.mu.RUnlock()
+
+	tools := make([]protocol.Tool, 0, len(register.entries))
+	for _, e := range register.entries {
+		tools = append(tools, e.tool)
+	}
+	return tools
+}
+
+func Execute(ctx context.Context, name string, args json.RawMessage) (Result, error) {
+	register.mu.RLock()
+	e, exists := register.entries[name]
+	register.mu.RUnlock()
+
+	if !exists {
+		return Result{}, fmt.Errorf("%w: %s", ErrNotFound, name)
+	}
+
+	result, err := e.handler(ctx, args)
+	if err != nil {
+		return Result{}, fmt.Errorf("tool %s execution failed: %w", name, err)
+	}
+
+	return result, nil
+}
+```
+
+### Step 11: Update `tools/README.md`
+
+Replace the existing skeleton content with updated status and usage.
+
+## Validation Criteria
+
+- [ ] `go vet ./...` passes
+- [ ] `go test ./...` passes (all existing tests updated for `protocol.Tool`)
+- [ ] `go mod tidy` produces no changes
+- [ ] `protocol.Tool` is the single canonical tool definition type
+- [ ] `agent.Tool` and `providers.ToolDefinition` no longer exist
+- [ ] `tools.Register`, `tools.Get`, `tools.List`, `tools.Execute` work correctly
+- [ ] Registry is thread-safe for concurrent access
+- [ ] Known Gaps updated in `_project/README.md`

--- a/.claude/context/sessions/12-tool-registry.md
+++ b/.claude/context/sessions/12-tool-registry.md
@@ -1,0 +1,45 @@
+# 12 - Tool Registry Interface and Execution
+
+## Summary
+
+Implemented the tools subsystem registry — a global singleton catalog of tool handlers following the `agent/providers/registry.go` pattern. Resolved the tool type duplication Known Gap by establishing `protocol.Tool` as the canonical tool definition type in `core/protocol`, replacing both `agent.Tool` and `providers.ToolDefinition`.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Tool type location | `core/protocol.Tool` | Define once at lowest level; both agent and tools consume directly. Resolves three-way duplication. |
+| Registry pattern | Global singleton with package-level functions | Matches providers registry pattern. Catalog of available tools, not the active set — kernel selects subset per turn. |
+| Register vs Replace | Separate functions with distinct semantics | Register rejects duplicates; Replace rejects missing tools. Enables future permission boundaries. |
+| No Registry interface | Package-level functions only | No scenario requires multiple registry instances. Consistent with providers. |
+
+## Files Modified
+
+- `core/protocol/tool.go` — new canonical Tool type
+- `agent/agent.go` — removed Tool struct, updated interface and implementation to use protocol.Tool
+- `agent/doc.go` — updated documentation references
+- `agent/mock/agent.go` — updated Tools() signature
+- `agent/providers/data.go` — removed ToolDefinition, updated ToolsData
+- `agent/request/tools.go` — updated to use protocol.Tool
+- `agent/agent_test.go` — updated test types
+- `agent/client/client_test.go` — updated test types
+- `agent/providers/base_test.go` — updated test types
+- `cmd/prompt-agent/main.go` — updated to use protocol.Tool
+- `tools/errors.go` — new sentinel errors
+- `tools/registry.go` — new global tool registry
+- `tools/registry_test.go` — new tests (13 tests, 100% coverage)
+- `tools/README.md` — updated with usage documentation
+- `_project/README.md` — removed tool type duplication Known Gap
+
+## Patterns Established
+
+- Global singleton registry pattern for subsystem catalogs (providers, tools)
+- Register/Replace separation for future permission modeling
+- Canonical types in `core/protocol` consumed directly by higher-level packages
+
+## Validation Results
+
+- `go vet ./...` — passes
+- `go test ./...` — all tests pass
+- `go mod tidy` — no changes
+- Tools package coverage: 100%

--- a/.claude/plans/fluffy-whistling-mango.md
+++ b/.claude/plans/fluffy-whistling-mango.md
@@ -1,0 +1,117 @@
+# Issue #12 — Tool Registry Interface and Execution
+
+## Context
+
+The tools subsystem needs a registry for tool handlers that maps LLM tool calls to their execution. Currently `agent.Tool` and `providers.ToolDefinition` are identical types defined in two places — introducing a third type would create three-way duplication.
+
+Per the project principle that *"exported data structures are the protocol — define once, consume directly at higher levels"*, the canonical `Tool` type belongs in `core/protocol` (the lowest affected level). Both `agent` and `tools` then consume it directly, resolving the Known Gap.
+
+The tools registry follows the **global singleton catalog pattern** established by `agent/providers/registry.go` — a thread-safe global registry with package-level functions (`Register`, `Get`, `List`, `Execute`). The registry is a catalog of all available tools, not the active set for a session. The kernel runtime selects which tools to offer the LLM from this catalog.
+
+Built-in tools (future) will self-register via `init()` in sub-packages. External libraries extend the catalog by calling `tools.Register()`. This matches the providers extensibility model exactly.
+
+## Step 1: Establish `protocol.Tool` as Canonical Type
+
+Move the tool definition type to `core/protocol` and update all consumers.
+
+### New file: `core/protocol/tool.go`
+
+```go
+type Tool struct {
+    Name        string         `json:"name"`
+    Description string         `json:"description"`
+    Parameters  map[string]any `json:"parameters"`
+}
+```
+
+### Update `agent` package
+
+- **`agent/agent.go`**: Remove `Tool` struct (lines 327-340). Update `Agent` interface and `agent.Tools()` method to use `protocol.Tool`. Remove the `[]Tool` → `[]providers.ToolDefinition` conversion loop (lines 224-231) — pass `[]protocol.Tool` through directly.
+- **`agent/doc.go`**: Update documentation references from `agent.Tool` to `protocol.Tool`.
+- **`agent/mock/agent.go`**: Update `MockAgent.Tools()` signature to `[]protocol.Tool`.
+
+### Update `providers` package
+
+- **`agent/providers/data.go`**: Remove `ToolDefinition` struct. Update `ToolsData.Tools` field to `[]protocol.Tool`.
+- **`agent/request/tools.go`**: Update `NewTools()` parameter and `toolsRequest.tools` field to `[]protocol.Tool`.
+
+### Update consumers
+
+- **`cmd/prompt-agent/main.go`**: Update `executeTools()` and `loadTools()` to use `[]protocol.Tool`.
+
+### Update tests
+
+- `agent/agent_test.go`: `[]agent.Tool` → `[]protocol.Tool`
+- `agent/mock/agent_test.go`: Update import if needed
+- `agent/client/client_test.go`: `[]providers.ToolDefinition` → `[]protocol.Tool`
+- `agent/providers/base_test.go`: `[]providers.ToolDefinition` → `[]protocol.Tool`
+
+### Update Known Gaps
+
+- **`_project/README.md`**: Remove the "Tool type duplication" Known Gap entry (item 2), since it's resolved.
+
+## Step 2: Tool Registry (Global Singleton)
+
+Build the global tool registry following the `agent/providers/registry.go` pattern. The tools package depends on `core/protocol` only.
+
+### New file: `tools/errors.go`
+
+Package-level sentinel errors:
+
+```go
+var (
+    ErrNotFound      = errors.New("tool not found")
+    ErrAlreadyExists = errors.New("tool already registered")
+    ErrEmptyName     = errors.New("tool name is empty")
+)
+```
+
+### New file: `tools/registry.go`
+
+**Types:**
+
+```go
+// Handler is the function signature for tool implementations.
+type Handler func(ctx context.Context, args json.RawMessage) (Result, error)
+
+// Result is the tool execution output that feeds back into the next LLM turn.
+type Result struct {
+    Content string
+    IsError bool
+}
+```
+
+**Global registry** (following providers/registry.go pattern):
+
+```go
+type entry struct {
+    tool    protocol.Tool
+    handler Handler
+}
+
+type registry struct {
+    entries map[string]entry
+    mu      sync.RWMutex
+}
+
+var register = &registry{
+    entries: make(map[string]entry),
+}
+```
+
+**Package-level functions:**
+
+- `Register(tool protocol.Tool, handler Handler) error` — validates non-empty name, rejects duplicates, stores entry
+- `Get(name string) (Handler, bool)` — RLock, lookup by name
+- `List() []protocol.Tool` — RLock, return all registered tool definitions (defensive copy)
+- `Execute(ctx context.Context, name string, args json.RawMessage) (Result, error)` — RLock to get handler, release lock, call handler, wrap errors with context
+
+### File updates
+
+- **`tools/README.md`**: Update status and add usage section showing the registration pattern.
+
+## Validation
+
+- `go vet ./...`
+- `go test ./...` (all existing + new tests pass)
+- `go mod tidy` produces no changes

--- a/_project/README.md
+++ b/_project/README.md
@@ -163,11 +163,9 @@ Models with strong reasoning but limited tool calling:
 
 ## Known Gaps
 
-Two limitations identified in the current codebase, deferred to per-subsystem concept sessions:
+One limitation identified in the current codebase, deferred to per-subsystem concept sessions:
 
 1. **Agent methods create fresh messages** — The `Agent` interface methods accept a `prompt string` and internally create a fresh message list. Incompatible with multi-turn conversations where full history must be passed. Deferred to agent subsystem redesign.
-
-2. **Tool type duplication** — Tool definitions exist in `agent.Tool` and `providers.ToolDefinition`. With tools introducing its own canonical type, this becomes a three-way duplication. Deferred to tools and agent concept sessions.
 
 ## Principles
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -293,7 +293,7 @@ func TestAgent_Tools(t *testing.T) {
 		t.Fatalf("New failed: %v", err)
 	}
 
-	tools := []agent.Tool{
+	tools := []protocol.Tool{
 		{
 			Name:        "get_weather",
 			Description: "Get weather for a location",

--- a/agent/client/client_test.go
+++ b/agent/client/client_test.go
@@ -9,11 +9,11 @@ import (
 	"time"
 
 	"github.com/tailored-agentic-units/kernel/agent/client"
+	"github.com/tailored-agentic-units/kernel/agent/providers"
+	"github.com/tailored-agentic-units/kernel/agent/request"
 	"github.com/tailored-agentic-units/kernel/core/config"
 	"github.com/tailored-agentic-units/kernel/core/model"
 	"github.com/tailored-agentic-units/kernel/core/protocol"
-	"github.com/tailored-agentic-units/kernel/agent/providers"
-	"github.com/tailored-agentic-units/kernel/agent/request"
 	"github.com/tailored-agentic-units/kernel/core/response"
 )
 
@@ -171,7 +171,7 @@ func TestClient_Execute_Tools(t *testing.T) {
 		protocol.NewMessage("user", "What's the weather in Boston?"),
 	}
 
-	tools := []providers.ToolDefinition{
+	tools := []protocol.Tool{
 		{
 			Name:        "get_weather",
 			Description: "Get current weather for a location",

--- a/agent/doc.go
+++ b/agent/doc.go
@@ -18,7 +18,7 @@
 //	    Vision(ctx context.Context, prompt string, images []string, opts ...map[string]any) (*types.ChatResponse, error)
 //	    VisionStream(ctx context.Context, prompt string, images []string, opts ...map[string]any) (<-chan types.StreamingChunk, error)
 //
-//	    Tools(ctx context.Context, prompt string, tools []Tool, opts ...map[string]any) (*types.ToolsResponse, error)
+//	    Tools(ctx context.Context, prompt string, tools []protocol.Tool, opts ...map[string]any) (*types.ToolsResponse, error)
 //
 //	    Embed(ctx context.Context, input string, opts ...map[string]any) (*types.EmbeddingsResponse, error)
 //	}
@@ -120,7 +120,7 @@
 //
 // Function calling with tool definitions:
 //
-//	tools := []agent.Tool{
+//	tools := []protocol.Tool{
 //	    {
 //	        Name:        "get_weather",
 //	        Description: "Get the current weather for a location",
@@ -212,12 +212,12 @@
 //
 // # Tool Definitions
 //
-// Tools follow the OpenAI function calling schema:
+// Tool definitions use the canonical protocol.Tool type from core/protocol:
 //
 //	type Tool struct {
-//	    Name        string         // Function name
-//	    Description string         // What the function does
-//	    Parameters  map[string]any // JSON Schema for parameters
+//	    Name        string         `json:"name"`        // Function name
+//	    Description string         `json:"description"` // What the function does
+//	    Parameters  map[string]any `json:"parameters"`  // JSON Schema for parameters
 //	}
 //
 // The Parameters field uses JSON Schema format:

--- a/agent/mock/agent.go
+++ b/agent/mock/agent.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/tailored-agentic-units/kernel/agent"
 	"github.com/tailored-agentic-units/kernel/agent/client"
+	"github.com/tailored-agentic-units/kernel/agent/providers"
 	"github.com/tailored-agentic-units/kernel/core/model"
 	"github.com/tailored-agentic-units/kernel/core/protocol"
-	"github.com/tailored-agentic-units/kernel/agent/providers"
 	"github.com/tailored-agentic-units/kernel/core/response"
 )
 
@@ -199,7 +199,7 @@ func (m *MockAgent) VisionStream(ctx context.Context, prompt string, images []st
 }
 
 // Tools returns the predetermined tools response.
-func (m *MockAgent) Tools(ctx context.Context, prompt string, tools []agent.Tool, opts ...map[string]any) (*response.ToolsResponse, error) {
+func (m *MockAgent) Tools(ctx context.Context, prompt string, tools []protocol.Tool, opts ...map[string]any) (*response.ToolsResponse, error) {
 	return m.toolsResponse, m.toolsError
 }
 

--- a/agent/providers/base_test.go
+++ b/agent/providers/base_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/tailored-agentic-units/kernel/core/protocol"
 	"github.com/tailored-agentic-units/kernel/agent/providers"
+	"github.com/tailored-agentic-units/kernel/core/protocol"
 )
 
 func TestNewBaseProvider(t *testing.T) {
@@ -121,7 +121,7 @@ func TestBaseProvider_Marshal_Tools(t *testing.T) {
 		Messages: []protocol.Message{
 			protocol.NewMessage("user", "What's the weather?"),
 		},
-		Tools: []providers.ToolDefinition{
+		Tools: []protocol.Tool{
 			{
 				Name:        "get_weather",
 				Description: "Get weather for a location",

--- a/agent/providers/data.go
+++ b/agent/providers/data.go
@@ -22,17 +22,8 @@ type VisionData struct {
 type ToolsData struct {
 	Model    string
 	Messages []protocol.Message
-	Tools    []ToolDefinition
+	Tools    []protocol.Tool
 	Options  map[string]any
-}
-
-// ToolDefinition represents a provider-agnostic tool (function) definition.
-// Providers transform this generic format to their specific API format
-// (OpenAI, Anthropic, Google, etc.).
-type ToolDefinition struct {
-	Name        string         `json:"name"`
-	Description string         `json:"description"`
-	Parameters  map[string]any `json:"parameters"` // JSON Schema
 }
 
 // EmbeddingsData contains the data needed to marshal an embeddings request.

--- a/agent/request/tools.go
+++ b/agent/request/tools.go
@@ -1,16 +1,16 @@
 package request
 
 import (
+	"github.com/tailored-agentic-units/kernel/agent/providers"
 	"github.com/tailored-agentic-units/kernel/core/model"
 	"github.com/tailored-agentic-units/kernel/core/protocol"
-	"github.com/tailored-agentic-units/kernel/agent/providers"
 )
 
 // ToolsRequest represents a tools (function calling) protocol request.
 // Separates tool definitions (protocol input data) from model configuration options.
 type ToolsRequest struct {
 	messages []protocol.Message
-	tools    []providers.ToolDefinition
+	tools    []protocol.Tool
 	options  map[string]any
 	provider providers.Provider
 	model    *model.Model
@@ -20,7 +20,7 @@ type ToolsRequest struct {
 // Messages contain the conversation history.
 // Tools define the available functions the model can call.
 // Options specify model configuration (temperature, max_tokens, etc.).
-func NewTools(p providers.Provider, m *model.Model, messages []protocol.Message, tools []providers.ToolDefinition, opts map[string]any) *ToolsRequest {
+func NewTools(p providers.Provider, m *model.Model, messages []protocol.Message, tools []protocol.Tool, opts map[string]any) *ToolsRequest {
 	return &ToolsRequest{
 		messages: messages,
 		tools:    tools,

--- a/cmd/prompt-agent/main.go
+++ b/cmd/prompt-agent/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/tailored-agentic-units/kernel/agent"
 	"github.com/tailored-agentic-units/kernel/core/config"
+	"github.com/tailored-agentic-units/kernel/core/protocol"
 )
 
 func main() {
@@ -156,7 +157,7 @@ func executeVisionStream(ctx context.Context, agent agent.Agent, prompt string, 
 	fmt.Println()
 }
 
-func executeTools(ctx context.Context, agent agent.Agent, prompt string, tools []agent.Tool) {
+func executeTools(ctx context.Context, agent agent.Agent, prompt string, tools []protocol.Tool) {
 	response, err := agent.Tools(ctx, prompt, tools)
 	if err != nil {
 		log.Fatalf("Tools failed: %v", err)
@@ -263,13 +264,13 @@ func executeEmbeddings(ctx context.Context, agent agent.Agent, input string) {
 	}
 }
 
-func loadTools(filename string) []agent.Tool {
+func loadTools(filename string) []protocol.Tool {
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		log.Fatalf("Failed to read tools file: %v", err)
 	}
 
-	var tools []agent.Tool
+	var tools []protocol.Tool
 	if err := json.Unmarshal(data, &tools); err != nil {
 		log.Fatalf("Failed to parse tools file: %v", err)
 	}

--- a/core/protocol/tool.go
+++ b/core/protocol/tool.go
@@ -1,0 +1,10 @@
+package protocol
+
+// Tool defines a function that can be called by the LLM.
+// This is the canonical tool definition type used across the kernel.
+// Parameters uses JSON Schema format to describe the function's input.
+type Tool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Parameters  map[string]any `json:"parameters"`
+}

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,7 +1,33 @@
 # tools
 
-Tool execution interface, registry, permissions, and built-in tools for the TAU (Tailored Agentic Units) kernel.
+Tool registry and execution for the TAU kernel. Provides a global catalog of tool handlers that maps LLM tool calls to their execution.
 
-## Status
+## Usage
 
-Under development. See [tau-platform](https://github.com/tailored-agentic-units/tau-platform) for ecosystem coordination and concept documents.
+```go
+import (
+    "github.com/tailored-agentic-units/kernel/tools"
+    "github.com/tailored-agentic-units/kernel/core/protocol"
+)
+
+// Register a tool
+tools.Register(protocol.Tool{
+    Name:        "get_weather",
+    Description: "Get weather for a location",
+    Parameters: map[string]any{
+        "type": "object",
+        "properties": map[string]any{
+            "location": map[string]any{"type": "string"},
+        },
+        "required": []string{"location"},
+    },
+}, weatherHandler)
+
+// List all registered tools
+available := tools.List()
+
+// Execute a tool by name
+result, err := tools.Execute(ctx, "get_weather", argsJSON)
+```
+
+Built-in tools register via `init()` in sub-packages. External libraries extend the catalog by calling `tools.Register()`.

--- a/tools/errors.go
+++ b/tools/errors.go
@@ -1,0 +1,10 @@
+package tools
+
+import "errors"
+
+// Sentinel errors for the tools registry.
+var (
+	ErrNotFound      = errors.New("tool not found")
+	ErrAlreadyExists = errors.New("tool already registered")
+	ErrEmptyName     = errors.New("tool name is empty")
+)

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -1,0 +1,122 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/tailored-agentic-units/kernel/core/protocol"
+)
+
+// Handler is the function signature for tool implementations.
+// Handlers receive the request context and JSON-encoded arguments from the LLM.
+type Handler func(ctx context.Context, args json.RawMessage) (Result, error)
+
+// Result is the tool execution output that feeds back into the next LLM turn.
+// IsError signals to the LLM that the tool invocation failed.
+type Result struct {
+	Content string
+	IsError bool
+}
+
+type entry struct {
+	tool    protocol.Tool
+	handler Handler
+}
+
+type registry struct {
+	entries map[string]entry
+	mu      sync.RWMutex
+}
+
+var register = &registry{
+	entries: make(map[string]entry),
+}
+
+// Register adds a new tool to the global registry.
+// Returns ErrAlreadyExists if a tool with the same name is already registered.
+// Use Replace to update an existing tool's handler.
+// Thread-safe for concurrent registration.
+func Register(tool protocol.Tool, handler Handler) error {
+	if tool.Name == "" {
+		return ErrEmptyName
+	}
+
+	register.mu.Lock()
+	defer register.mu.Unlock()
+
+	if _, exists := register.entries[tool.Name]; exists {
+		return fmt.Errorf("%w: %s", ErrAlreadyExists, tool.Name)
+	}
+
+	register.entries[tool.Name] = entry{tool: tool, handler: handler}
+	return nil
+}
+
+// Replace updates an existing tool's definition and handler.
+// Returns ErrNotFound if no tool with the given name is registered.
+// Thread-safe for concurrent access.
+func Replace(tool protocol.Tool, handler Handler) error {
+	if tool.Name == "" {
+		return ErrEmptyName
+	}
+
+	register.mu.Lock()
+	defer register.mu.Unlock()
+
+	if _, exists := register.entries[tool.Name]; !exists {
+		return fmt.Errorf("%w: %s", ErrNotFound, tool.Name)
+	}
+
+	register.entries[tool.Name] = entry{tool: tool, handler: handler}
+	return nil
+}
+
+// Get retrieves a handler by tool name.
+// Returns the handler and true if found, nil and false otherwise.
+// Thread-safe for concurrent access.
+func Get(name string) (Handler, bool) {
+	register.mu.RLock()
+	defer register.mu.RUnlock()
+
+	e, exists := register.entries[name]
+	if !exists {
+		return nil, false
+	}
+	return e.handler, true
+}
+
+// List returns the definitions of all registered tools.
+// Thread-safe for concurrent access.
+func List() []protocol.Tool {
+	register.mu.RLock()
+	defer register.mu.RUnlock()
+
+	tools := make([]protocol.Tool, 0, len(register.entries))
+	for _, e := range register.entries {
+		tools = append(tools, e.tool)
+	}
+	return tools
+}
+
+// Execute dispatches a tool call to the registered handler by name.
+// Returns ErrNotFound if the tool is not registered.
+// Handler errors are wrapped with the tool name for context.
+// Thread-safe for concurrent execution.
+func Execute(ctx context.Context, name string, args json.RawMessage) (Result, error) {
+	register.mu.RLock()
+	e, exists := register.entries[name]
+	register.mu.RUnlock()
+
+	if !exists {
+		return Result{}, fmt.Errorf("%w: %s", ErrNotFound, name)
+	}
+
+	result, err := e.handler(ctx, args)
+	if err != nil {
+		return Result{}, fmt.Errorf("tool %s execution failed: %w", name, err)
+	}
+
+	return result, nil
+}

--- a/tools/registry_test.go
+++ b/tools/registry_test.go
@@ -1,0 +1,245 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/tailored-agentic-units/kernel/core/protocol"
+	"github.com/tailored-agentic-units/kernel/tools"
+)
+
+func testTool(name string) protocol.Tool {
+	return protocol.Tool{
+		Name:        name,
+		Description: "test tool: " + name,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"input": map[string]any{"type": "string"},
+			},
+		},
+	}
+}
+
+func echoHandler(_ context.Context, args json.RawMessage) (tools.Result, error) {
+	return tools.Result{Content: string(args)}, nil
+}
+
+func TestRegister(t *testing.T) {
+	tests := []struct {
+		name    string
+		tool    protocol.Tool
+		wantErr error
+	}{
+		{
+			name: "valid tool",
+			tool: testTool("register_valid"),
+		},
+		{
+			name:    "empty name",
+			tool:    protocol.Tool{Name: ""},
+			wantErr: tools.ErrEmptyName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tools.Register(tt.tool, echoHandler)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("Register() error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Register() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRegister_Duplicate(t *testing.T) {
+	tool := testTool("register_duplicate")
+
+	if err := tools.Register(tool, echoHandler); err != nil {
+		t.Fatalf("first Register() failed: %v", err)
+	}
+
+	err := tools.Register(tool, echoHandler)
+	if !errors.Is(err, tools.ErrAlreadyExists) {
+		t.Errorf("second Register() error = %v, want %v", err, tools.ErrAlreadyExists)
+	}
+}
+
+func TestReplace(t *testing.T) {
+	tool := testTool("replace_existing")
+
+	if err := tools.Register(tool, echoHandler); err != nil {
+		t.Fatalf("Register() failed: %v", err)
+	}
+
+	replacementHandler := func(_ context.Context, _ json.RawMessage) (tools.Result, error) {
+		return tools.Result{Content: "replaced"}, nil
+	}
+
+	if err := tools.Replace(tool, replacementHandler); err != nil {
+		t.Fatalf("Replace() failed: %v", err)
+	}
+
+	result, err := tools.Execute(context.Background(), "replace_existing", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute() after Replace() failed: %v", err)
+	}
+	if result.Content != "replaced" {
+		t.Errorf("Execute() content = %q, want %q", result.Content, "replaced")
+	}
+}
+
+func TestReplace_NotFound(t *testing.T) {
+	tool := testTool("replace_nonexistent")
+
+	err := tools.Replace(tool, echoHandler)
+	if !errors.Is(err, tools.ErrNotFound) {
+		t.Errorf("Replace() error = %v, want %v", err, tools.ErrNotFound)
+	}
+}
+
+func TestReplace_EmptyName(t *testing.T) {
+	err := tools.Replace(protocol.Tool{Name: ""}, echoHandler)
+	if !errors.Is(err, tools.ErrEmptyName) {
+		t.Errorf("Replace() error = %v, want %v", err, tools.ErrEmptyName)
+	}
+}
+
+func TestGet(t *testing.T) {
+	tool := testTool("get_existing")
+
+	if err := tools.Register(tool, echoHandler); err != nil {
+		t.Fatalf("Register() failed: %v", err)
+	}
+
+	handler, exists := tools.Get("get_existing")
+	if !exists {
+		t.Fatal("Get() returned exists=false, want true")
+	}
+	if handler == nil {
+		t.Fatal("Get() returned nil handler")
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	_, exists := tools.Get("get_nonexistent")
+	if exists {
+		t.Error("Get() returned exists=true for nonexistent tool")
+	}
+}
+
+func TestList(t *testing.T) {
+	tool1 := testTool("list_tool_1")
+	tool2 := testTool("list_tool_2")
+
+	tools.Register(tool1, echoHandler)
+	tools.Register(tool2, echoHandler)
+
+	list := tools.List()
+
+	found1, found2 := false, false
+	for _, tool := range list {
+		if tool.Name == "list_tool_1" {
+			found1 = true
+		}
+		if tool.Name == "list_tool_2" {
+			found2 = true
+		}
+	}
+
+	if !found1 {
+		t.Error("List() missing list_tool_1")
+	}
+	if !found2 {
+		t.Error("List() missing list_tool_2")
+	}
+}
+
+func TestExecute(t *testing.T) {
+	tool := testTool("execute_valid")
+	handler := func(_ context.Context, args json.RawMessage) (tools.Result, error) {
+		var params struct {
+			Input string `json:"input"`
+		}
+		if err := json.Unmarshal(args, &params); err != nil {
+			return tools.Result{}, err
+		}
+		return tools.Result{Content: "echo: " + params.Input}, nil
+	}
+
+	if err := tools.Register(tool, handler); err != nil {
+		t.Fatalf("Register() failed: %v", err)
+	}
+
+	result, err := tools.Execute(
+		context.Background(),
+		"execute_valid",
+		json.RawMessage(`{"input":"hello"}`),
+	)
+	if err != nil {
+		t.Fatalf("Execute() failed: %v", err)
+	}
+	if result.Content != "echo: hello" {
+		t.Errorf("Execute() content = %q, want %q", result.Content, "echo: hello")
+	}
+	if result.IsError {
+		t.Error("Execute() IsError = true, want false")
+	}
+}
+
+func TestExecute_NotFound(t *testing.T) {
+	_, err := tools.Execute(context.Background(), "execute_nonexistent", nil)
+	if !errors.Is(err, tools.ErrNotFound) {
+		t.Errorf("Execute() error = %v, want %v", err, tools.ErrNotFound)
+	}
+}
+
+func TestExecute_HandlerError(t *testing.T) {
+	tool := testTool("execute_error")
+	handlerErr := errors.New("handler failed")
+	handler := func(_ context.Context, _ json.RawMessage) (tools.Result, error) {
+		return tools.Result{}, handlerErr
+	}
+
+	if err := tools.Register(tool, handler); err != nil {
+		t.Fatalf("Register() failed: %v", err)
+	}
+
+	_, err := tools.Execute(context.Background(), "execute_error", nil)
+	if err == nil {
+		t.Fatal("Execute() expected error, got nil")
+	}
+	if !errors.Is(err, handlerErr) {
+		t.Errorf("Execute() error chain does not contain handler error: %v", err)
+	}
+}
+
+func TestExecute_RespectsContext(t *testing.T) {
+	tool := testTool("execute_ctx")
+	handler := func(ctx context.Context, _ json.RawMessage) (tools.Result, error) {
+		if err := ctx.Err(); err != nil {
+			return tools.Result{}, err
+		}
+		return tools.Result{Content: "ok"}, nil
+	}
+
+	if err := tools.Register(tool, handler); err != nil {
+		t.Fatalf("Register() failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := tools.Execute(ctx, "execute_ctx", nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Execute() error = %v, want context.Canceled", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Establish `protocol.Tool` as the canonical tool definition type in `core/protocol`, replacing both `agent.Tool` and `providers.ToolDefinition` — resolves the tool type duplication Known Gap
- Implement global tool registry in `tools/` following the `agent/providers/registry.go` singleton catalog pattern with `Register`, `Replace`, `Get`, `List`, and `Execute`
- `Register` and `Replace` have distinct semantics to enable future permission boundaries

Closes #12

## Changes

- `core/protocol/tool.go` — new canonical `Tool` type with JSON tags
- `agent/agent.go` — removed `Tool` struct, updated interface and implementation to use `protocol.Tool`, eliminated conversion loop
- `agent/providers/data.go` — removed `ToolDefinition`, updated `ToolsData` to use `protocol.Tool`
- `agent/request/tools.go` — updated to use `protocol.Tool`
- `agent/mock/agent.go` — updated `Tools()` signature
- `agent/doc.go` — updated documentation references
- `cmd/prompt-agent/main.go` — updated to use `protocol.Tool`
- `tools/registry.go` — global singleton registry with `Register`, `Replace`, `Get`, `List`, `Execute`
- `tools/errors.go` — sentinel errors (`ErrNotFound`, `ErrAlreadyExists`, `ErrEmptyName`)
- `tools/registry_test.go` — 13 tests, 100% coverage
- `_project/README.md` — removed tool type duplication Known Gap
- All existing tests updated for `protocol.Tool`