### PR TITLE
Add memory store interface and session-scoped cache

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -33,10 +33,9 @@ kernel/
 ├── core/               # Foundational types: protocol, response, config, model
 ├── agent/              # LLM communication: agent interface, client, providers, request, mock
 ├── orchestrate/        # Multi-agent coordination: hub, messaging, state, workflows, observability
-├── memory/             # Persistent memory (skeleton)
+├── memory/             # Context composition: persistent memory, skills, agent profiles (skeleton)
 ├── tools/              # Tool execution (skeleton)
 ├── session/            # Conversation management (skeleton)
-├── skills/             # Progressive disclosure (skeleton)
 ├── mcp/                # MCP client (skeleton)
 ├── kernel/             # Runtime loop + ConnectRPC composition (skeleton)
 ├── rpc/                # ConnectRPC infrastructure (proto, buf configs, generated code)

--- a/.claude/context/guides/.archive/13-memory-store.md
+++ b/.claude/context/guides/.archive/13-memory-store.md
@@ -1,0 +1,435 @@
+# 13 - Memory Store Interface and Filesystem Implementation
+
+## Problem Context
+
+The memory subsystem is the single context composition pipeline for the TAU kernel. It provides a hierarchical key-value namespace backed by pluggable storage, with session-scoped caching and progressive loading. The kernel loads context at session initialization and accesses it locally — no constant I/O to external systems.
+
+The memory package currently contains only a README.md skeleton. This implementation establishes the full architecture: persistence interface (Store), filesystem backend (FileStore), and session-scoped cache with progressive loading (Cache).
+
+## Architecture Approach
+
+Two types work together:
+
+- **Store** — stateless persistence abstraction. Translates between external storage and internal `[]byte` entries keyed by `/`-separated paths. The kernel requires `[]byte` values; external systems handle transformations.
+- **Cache** — session-scoped cache. Bootstraps an index of available keys, progressively loads content on demand, tracks dirty state, and flushes changes back through the Store.
+
+Keys are `/`-separated hierarchical paths that map 1:1 to filesystem paths in the FileStore. Three namespace conventions: `memory/` (core agent memory), `skills/` (skill definitions), `agents/` (sub-agent profiles).
+
+Progressive loading: Bootstrap populates the key index and eagerly loads specified prefixes. Additional content is resolved on demand via `Resolve`. Reads never trigger I/O.
+
+## Implementation
+
+### Step 1: Sentinel Errors (`memory/errors.go`)
+
+New file:
+
+```go
+package memory
+
+import "errors"
+
+var (
+	ErrKeyNotFound = errors.New("key not found")
+	ErrLoadFailed  = errors.New("load failed")
+	ErrSaveFailed  = errors.New("save failed")
+)
+```
+
+### Step 2: Entry Type and Namespace Constants (`memory/entry.go`)
+
+New file:
+
+```go
+package memory
+
+const (
+	NamespaceMemory = "memory"
+	NamespaceSkills = "skills"
+	NamespaceAgents = "agents"
+)
+
+type Entry struct {
+	Key   string
+	Value []byte
+}
+```
+
+### Step 3: Store Interface (`memory/store.go`)
+
+New file:
+
+```go
+package memory
+
+import "context"
+
+type Store interface {
+	List(ctx context.Context) ([]string, error)
+	Load(ctx context.Context, keys ...string) ([]Entry, error)
+	Save(ctx context.Context, entries ...Entry) error
+	Delete(ctx context.Context, keys ...string) error
+}
+```
+
+### Step 4: FileStore Implementation (`memory/filestore.go`)
+
+New file. The FileStore maps keys 1:1 to filesystem paths under a root directory.
+
+```go
+package memory
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type fileStore struct {
+	root string
+}
+
+func NewFileStore(root string) Store {
+	return &fileStore{root: root}
+}
+
+func (s *fileStore) List(_ context.Context) ([]string, error) {
+	var keys []string
+
+	err := filepath.WalkDir(s.root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) && path == s.root {
+				return fs.SkipAll
+			}
+			return err
+		}
+
+		// Skip hidden files and directories
+		if strings.HasPrefix(d.Name(), ".") {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(s.root, path)
+		if err != nil {
+			return err
+		}
+		keys = append(keys, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrLoadFailed, err)
+	}
+
+	return keys, nil
+}
+
+func (s *fileStore) Load(_ context.Context, keys ...string) ([]Entry, error) {
+	entries := make([]Entry, 0, len(keys))
+
+	for _, key := range keys {
+		path := filepath.Join(s.root, filepath.FromSlash(key))
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, fmt.Errorf("%w: %s", ErrKeyNotFound, key)
+			}
+			return nil, fmt.Errorf("%w: %s: %v", ErrLoadFailed, key, err)
+		}
+		entries = append(entries, Entry{Key: key, Value: data})
+	}
+
+	return entries, nil
+}
+
+func (s *fileStore) Save(_ context.Context, entries ...Entry) error {
+	for _, e := range entries {
+		path := filepath.Join(s.root, filepath.FromSlash(e.Key))
+
+		dir := filepath.Dir(path)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("%w: %s: %v", ErrSaveFailed, e.Key, err)
+		}
+
+		// Atomic write: temp file in same directory, then rename
+		tmp, err := os.CreateTemp(dir, ".tmp-*")
+		if err != nil {
+			return fmt.Errorf("%w: %s: %v", ErrSaveFailed, e.Key, err)
+		}
+		tmpName := tmp.Name()
+
+		if _, err := tmp.Write(e.Value); err != nil {
+			tmp.Close()
+			os.Remove(tmpName)
+			return fmt.Errorf("%w: %s: %v", ErrSaveFailed, e.Key, err)
+		}
+		if err := tmp.Close(); err != nil {
+			os.Remove(tmpName)
+			return fmt.Errorf("%w: %s: %v", ErrSaveFailed, e.Key, err)
+		}
+
+		if err := os.Rename(tmpName, path); err != nil {
+			os.Remove(tmpName)
+			return fmt.Errorf("%w: %s: %v", ErrSaveFailed, e.Key, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *fileStore) Delete(_ context.Context, keys ...string) error {
+	for _, key := range keys {
+		path := filepath.Join(s.root, filepath.FromSlash(key))
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("delete failed: %s: %w", key, err)
+		}
+
+		// Clean up empty parent directories up to root
+		dir := filepath.Dir(path)
+		for dir != s.root {
+			if err := os.Remove(dir); err != nil {
+				break // Not empty or other error — stop climbing
+			}
+			dir = filepath.Dir(dir)
+		}
+	}
+
+	return nil
+}
+```
+
+### Step 5: Cache Implementation (`memory/cache.go`)
+
+New file. The Cache is the session-scoped cache with progressive loading.
+
+```go
+package memory
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+)
+
+type Cache struct {
+	store   Store
+	cache   map[string][]byte
+	index   map[string]bool
+	dirty   map[string]bool
+	removed map[string]bool
+	mu      sync.RWMutex
+}
+
+func NewCache(store Store) *Cache {
+	return &Cache{
+		store:   store,
+		cache:   make(map[string][]byte),
+		index:   make(map[string]bool),
+		dirty:   make(map[string]bool),
+		removed: make(map[string]bool),
+	}
+}
+
+// Bootstrap loads the store index and caches entries matching the given prefixes.
+// With no prefixes, only the index is populated.
+func (c *Cache) Bootstrap(ctx context.Context, prefixes ...string) error {
+	keys, err := c.store.List(ctx)
+	if err != nil {
+		return fmt.Errorf("bootstrap index: %w", err)
+	}
+
+	c.mu.Lock()
+	for _, key := range keys {
+		c.index[key] = true
+	}
+	c.mu.Unlock()
+
+	if len(prefixes) == 0 {
+		return nil
+	}
+
+	// Collect keys matching any prefix
+	var toLoad []string
+	for _, key := range keys {
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(key, prefix) {
+				toLoad = append(toLoad, key)
+				break
+			}
+		}
+	}
+
+	if len(toLoad) == 0 {
+		return nil
+	}
+
+	entries, err := c.store.Load(ctx, toLoad...)
+	if err != nil {
+		return fmt.Errorf("bootstrap load: %w", err)
+	}
+
+	c.mu.Lock()
+	for _, e := range entries {
+		c.cache[e.Key] = e.Value
+	}
+	c.mu.Unlock()
+
+	return nil
+}
+
+// Resolve loads specific entries from the store into the cache.
+// Already-cached keys are skipped.
+func (c *Cache) Resolve(ctx context.Context, keys ...string) error {
+	c.mu.RLock()
+	var toLoad []string
+	for _, key := range keys {
+		if _, cached := c.cache[key]; !cached {
+			toLoad = append(toLoad, key)
+		}
+	}
+	c.mu.RUnlock()
+
+	if len(toLoad) == 0 {
+		return nil
+	}
+
+	entries, err := c.store.Load(ctx, toLoad...)
+	if err != nil {
+		return fmt.Errorf("resolve: %w", err)
+	}
+
+	c.mu.Lock()
+	for _, e := range entries {
+		c.cache[e.Key] = e.Value
+		c.index[e.Key] = true
+	}
+	c.mu.Unlock()
+
+	return nil
+}
+
+// Flush persists dirty entries and removes deleted entries through the store.
+func (c *Cache) Flush(ctx context.Context) error {
+	c.mu.RLock()
+	var toSave []Entry
+	for key := range c.dirty {
+		if val, ok := c.cache[key]; ok {
+			toSave = append(toSave, Entry{Key: key, Value: val})
+		}
+	}
+	var toDelete []string
+	for key := range c.removed {
+		toDelete = append(toDelete, key)
+	}
+	c.mu.RUnlock()
+
+	if len(toSave) > 0 {
+		if err := c.store.Save(ctx, toSave...); err != nil {
+			return fmt.Errorf("flush save: %w", err)
+		}
+	}
+
+	if len(toDelete) > 0 {
+		if err := c.store.Delete(ctx, toDelete...); err != nil {
+			return fmt.Errorf("flush delete: %w", err)
+		}
+	}
+
+	c.mu.Lock()
+	c.dirty = make(map[string]bool)
+	c.removed = make(map[string]bool)
+	c.mu.Unlock()
+
+	return nil
+}
+
+func (c *Cache) Get(key string) ([]byte, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	val, ok := c.cache[key]
+	if !ok {
+		return nil, false
+	}
+	return slices.Clone(val), true
+}
+
+func (c *Cache) Set(key string, value []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cache[key] = slices.Clone(value)
+	c.index[key] = true
+	c.dirty[key] = true
+	delete(c.removed, key)
+}
+
+func (c *Cache) Delete(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	delete(c.cache, key)
+	delete(c.index, key)
+	delete(c.dirty, key)
+	c.removed[key] = true
+}
+
+func (c *Cache) Has(key string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.index[key]
+}
+
+func (c *Cache) Keys() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	keys := make([]string, 0, len(c.index))
+	for key := range c.index {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (c *Cache) Entries(prefix string) []Entry {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	var entries []Entry
+	for key, val := range c.cache {
+		if strings.HasPrefix(key, prefix) {
+			entries = append(entries, Entry{Key: key, Value: slices.Clone(val)})
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Key < entries[j].Key
+	})
+	return entries
+}
+```
+
+## Validation Criteria
+
+- [ ] `Store` interface defined in `memory/store.go`
+- [ ] `FileStore` implementation in `memory/filestore.go`
+- [ ] `Cache` with progressive loading in `memory/context.go`
+- [ ] `List`/`Load`/`Save`/`Delete` round-trips data correctly
+- [ ] Handles empty/missing root directory on first List (empty index, no error)
+- [ ] Progressive loading: Bootstrap loads index + prefixes, Resolve loads on demand
+- [ ] Thread-safe for concurrent Get/Set
+- [ ] Flush persists only dirty entries
+- [ ] Tests co-located, black-box style (`memory_test` package)
+- [ ] `go vet ./memory/...` passes
+- [ ] `go mod tidy` produces no changes

--- a/.claude/context/sessions/13-memory-store.md
+++ b/.claude/context/sessions/13-memory-store.md
@@ -1,0 +1,47 @@
+# 13 - Memory Store Interface and Filesystem Implementation
+
+## Summary
+
+Implemented the memory subsystem as the unified context composition pipeline for the TAU kernel. The package provides a hierarchical key-value namespace with two core types: Store (persistence abstraction) and Cache (session-scoped cache with progressive loading). Includes a filesystem-based Store implementation (FileStore) that maps keys 1:1 to relative file paths. Removed the standalone `skills/` skeleton package since skills are now a namespace within the memory system.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Expanded scope | Memory as unified context pipeline | Consolidates memory, skills, and agent profiles into a single namespace with shared persistence and caching semantics |
+| Value type | `[]byte` | Kernel's contract — external systems handle transformations |
+| Key format | `/`-separated paths | Maps 1:1 to filesystem paths, natural hierarchy separator for any backend |
+| Namespace naming | `memory/`, `skills/`, `agents/` | `memory` for core agent memory, `agents` aligns with Claude convention |
+| Cache vs Context naming | `Cache` | Avoids conflation with `context.Context` in function signatures |
+| Namespace constants | Untyped strings | Used as prefix conventions in string operations, not discrete enum values |
+| Progressive loading | Bootstrap indexes, Resolve loads on demand | Supports three-level skill access pattern without eager loading |
+| Store ordering | Unspecified | FileStore naturally returns sorted (WalkDir), but interface doesn't guarantee it |
+
+## Files Modified
+
+- `memory/errors.go` — created: sentinel errors
+- `memory/entry.go` — created: Entry type, namespace constants
+- `memory/store.go` — created: Store interface, package doc
+- `memory/filestore.go` — created: filesystem Store implementation
+- `memory/cache.go` — created: session-scoped Cache with progressive loading
+- `memory/filestore_test.go` — created: 12 FileStore tests
+- `memory/cache_test.go` — created: 19 Cache tests
+- `memory/README.md` — updated description
+- `README.md` — removed `skills/` row, updated `memory/` description
+- `.claude/CLAUDE.md` — removed `skills/` from structure, updated `memory/` description
+- `skills/` — removed (skeleton consolidated into memory)
+
+## Patterns Established
+
+- **Store interface**: Stateless persistence with `List`, `Load`, `Save`, `Delete` — any backend implements this to participate in the context pipeline
+- **Cache progressive loading**: `Bootstrap` (index + prefixes) → `Resolve` (on demand) → `Get` (local read) → `Flush` (persist dirty)
+- **Defensive copies**: `Get` and `Set` clone byte slices to prevent external mutation
+- **Namespace conventions**: `memory/`, `skills/`, `agents/` as top-level key prefixes
+
+## Validation Results
+
+- `go vet ./...` — clean
+- `go test ./...` — all packages pass
+- `go mod tidy` — no changes
+- Memory package: 31 tests, 88.2% coverage
+- Uncovered: defensive OS-level error paths in Save/List (acceptable)

--- a/.claude/plans/curried-foraging-lagoon.md
+++ b/.claude/plans/curried-foraging-lagoon.md
@@ -1,0 +1,171 @@
+# Issue #13 — Memory Store Interface and Filesystem Implementation
+
+## Context
+
+The memory subsystem is the single context composition pipeline for the TAU kernel. It provides a hierarchical key-value namespace backed by pluggable storage, with session-scoped caching and progressive loading. The kernel loads context at session initialization and accesses it locally — no constant I/O to external systems.
+
+This is a Phase 1 foundation subsystem with zero internal kernel dependencies. The memory package currently contains only a README.md skeleton.
+
+**Expanded scope**: Beyond the minimal Store from the original issue, this implementation establishes the memory system as the unified context pipeline for notes, skills, and profiles — with progressive loading support for the three-level skill access pattern.
+
+## Architecture
+
+### Data Model
+
+- **Keys**: `/`-separated hierarchical paths (like relative filesystem paths)
+- **Values**: `[]byte` (raw content — the kernel's contract)
+- **Namespaces**: `memory/`, `skills/`, `agents/` (top-level conventions)
+
+Example key layout:
+```
+memory/global.md                    # Always-loaded agent memory
+memory/project/kernel.md            # Project-scoped memory
+skills/go-patterns/SKILL.md         # Skill definition (metadata + instructions)
+skills/go-patterns/resources/...    # Skill resources (on-demand)
+agents/explorer.json                # Sub-agent profile
+```
+
+### Interfaces
+
+**Store** — persistence abstraction (stateless, handles I/O):
+```go
+type Store interface {
+    List(ctx context.Context) ([]string, error)              // Discover available keys
+    Load(ctx context.Context, keys ...string) ([]Entry, error)  // Fetch specific entries
+    Save(ctx context.Context, entries ...Entry) error         // Persist entries
+    Delete(ctx context.Context, keys ...string) error         // Remove entries
+}
+```
+
+**Context** — session-scoped cache (stateful, no I/O on reads):
+```go
+func NewContext(store Store) *Context
+func (c *Context) Bootstrap(ctx context.Context, prefixes ...string) error  // Index + load matching prefixes
+func (c *Context) Resolve(ctx context.Context, keys ...string) error        // Load specific entries on demand
+func (c *Context) Flush(ctx context.Context) error                          // Persist dirty entries
+
+func (c *Context) Get(key string) ([]byte, bool)  // Read cached content
+func (c *Context) Set(key string, value []byte)    // Update cache (marks dirty)
+func (c *Context) Delete(key string)               // Remove from cache (marks for deletion)
+func (c *Context) Has(key string) bool              // Key exists in index (loaded or not)
+func (c *Context) Keys() []string                   // All indexed keys
+func (c *Context) Entries(prefix string) []Entry    // Cached entries matching prefix
+```
+
+### Progressive Loading Flow
+
+```
+Bootstrap("memory/")
+  → Store.List() → populate index (all available keys)
+  → Store.Load("memory/*") → cache matching entries
+
+During session:
+  → Has("skills/go-patterns/SKILL.md") → true (in index)
+  → Get("skills/go-patterns/SKILL.md") → nil, false (not cached)
+  → Resolve(ctx, "skills/go-patterns/SKILL.md") → loads into cache
+  → Get("skills/go-patterns/SKILL.md") → content, true
+
+On flush:
+  → Flush(ctx) → Save dirty entries, Delete removed entries
+```
+
+### FileStore Translation
+
+FileStore maps filesystem structure 1:1 to the key namespace:
+- `{root}/memory/global.md` → key `"memory/global.md"`
+- `{root}/skills/go-patterns/SKILL.md` → key `"skills/go-patterns/SKILL.md"`
+- `{root}/agents/explorer.json` → key `"agents/explorer.json"`
+
+No extension stripping, no path transformation. Keys ARE relative filesystem paths. This is the simplest storage-to-namespace translation — other Store implementations (database, ConnectRPC) would define their own mapping.
+
+## File Plan
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `memory/entry.go` | Create | Entry type, namespace constants |
+| `memory/store.go` | Create | Store interface |
+| `memory/filestore.go` | Create | Filesystem Store implementation |
+| `memory/context.go` | Create | Session-scoped context cache |
+| `memory/errors.go` | Create | Sentinel errors |
+
+## Implementation
+
+### Step 1: Sentinel errors (`memory/errors.go`)
+
+Error variables for storage operations:
+- `ErrKeyNotFound` — requested key not in store
+- `ErrLoadFailed` — wrapping context for storage read failures
+- `ErrSaveFailed` — wrapping context for storage write failures
+
+### Step 2: Entry type and namespace constants (`memory/entry.go`)
+
+```go
+type Entry struct {
+    Key   string
+    Value []byte
+}
+```
+
+Namespace constants:
+```go
+const (
+    NamespaceMemory = "memory"
+    NamespaceSkills = "skills"
+    NamespaceAgents = "agents"
+)
+```
+
+### Step 3: Store interface (`memory/store.go`)
+
+The `Store` interface as defined in the Architecture section above. Stateless persistence contract.
+
+### Step 4: FileStore implementation (`memory/filestore.go`)
+
+Constructor: `NewFileStore(root string) Store`
+
+Behaviors:
+- **List**: `filepath.WalkDir` the root, return relative paths for all regular files. Skip hidden files/dirs (`.` prefix).
+- **Load**: For each requested key, read `filepath.Join(root, key)`. Return `ErrKeyNotFound` wrapped if file missing.
+- **Save**: For each entry, write to `filepath.Join(root, key)`. Create parent directories with `os.MkdirAll`. Use atomic write (temp file + rename).
+- **Delete**: For each key, `os.Remove(filepath.Join(root, key))`. Ignore not-found errors. Clean up empty parent directories.
+
+### Step 5: Context implementation (`memory/context.go`)
+
+Internal state:
+```go
+type Context struct {
+    store   Store
+    cache   map[string][]byte  // loaded content
+    index   map[string]bool    // all known keys
+    dirty   map[string]bool    // modified since last flush
+    removed map[string]bool    // deleted since last flush
+    mu      sync.RWMutex
+}
+```
+
+Key behaviors:
+- **Bootstrap(ctx, prefixes...)**: Calls `Store.List` to populate index. If prefixes given, calls `Store.Load` for matching keys and populates cache.
+- **Resolve(ctx, keys...)**: Skips already-cached keys. Loads remaining from Store. Adds to cache.
+- **Get(key)**: Read-locked cache lookup. Returns `nil, false` if not loaded.
+- **Set(key, value)**: Write-locked. Updates cache, adds to index, marks dirty.
+- **Delete(key)**: Write-locked. Removes from cache, marks for deletion.
+- **Has(key)**: Read-locked index lookup.
+- **Keys()**: Read-locked. Returns sorted slice of all indexed keys.
+- **Entries(prefix)**: Read-locked. Returns cached entries whose keys start with prefix.
+- **Flush(ctx)**: Calls `Store.Save` for dirty entries, `Store.Delete` for removed entries. Clears dirty/removed tracking.
+
+Thread-safety: `sync.RWMutex` — reads use `RLock`, writes use `Lock`.
+
+## Validation Criteria
+
+- [ ] `Store` interface defined in `memory/store.go`
+- [ ] `FileStore` implementation in `memory/filestore.go`
+- [ ] `Context` with progressive loading in `memory/context.go`
+- [ ] `List`/`Load`/`Save`/`Delete` round-trips data correctly
+- [ ] Handles empty/missing root directory on first List (empty index, no error)
+- [ ] Progressive loading: Bootstrap loads index + prefixes, Resolve loads on demand
+- [ ] Thread-safe for concurrent Get/Set
+- [ ] Flush persists only dirty entries
+- [ ] Tests co-located, black-box style (`memory_test` package)
+- [ ] `go vet ./memory/...` passes
+- [ ] `go mod tidy` produces no changes

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,5 @@
       "Skill(tau:tau-overview)"
     ]
   },
-  "enabledPlugins": {},
-  "extraKnownMarketplaces": {},
   "plansDirectory": "./.claude/plans"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.1.0-dev.1.13
+
+### memory
+
+- Add `Store` interface for pluggable persistence with `List`, `Load`, `Save`, `Delete` (#13)
+- Add `FileStore` filesystem implementation with atomic writes and hidden file filtering (#13)
+- Add `Cache` session-scoped context cache with progressive loading via `Bootstrap`, `Resolve`, `Flush` (#13)
+- Add `Entry` type and namespace constants (`memory`, `skills`, `agents`) (#13)
+- Consolidate `skills/` skeleton into memory package as a namespace convention (#13)
+
 ## v0.1.0-dev.1.12
 
 ### core

--- a/README.md
+++ b/README.md
@@ -15,10 +15,9 @@ github.com/tailored-agentic-units/kernel
 | `core/` | Foundational type vocabulary: protocol constants, response types, configuration, model |
 | `agent/` | LLM communication: agent interface, HTTP client, providers (Ollama, Azure), request construction |
 | `orchestrate/` | Multi-agent coordination: hubs, messaging, state graphs, workflow patterns, observability |
-| `memory/` | Persistent memory (under development) |
+| `memory/` | Context composition pipeline: persistent memory, skills, agent profiles (under development) |
 | `tools/` | Tool execution and registry (under development) |
 | `session/` | Conversation history management (under development) |
-| `skills/` | Progressive disclosure skill system (under development) |
 | `mcp/` | Model Context Protocol client (under development) |
 | `kernel/` | Runtime loop and ConnectRPC composition (under development) |
 

--- a/memory/README.md
+++ b/memory/README.md
@@ -1,7 +1,3 @@
 # memory
 
-Filesystem-based persistent memory for the TAU (Tailored Agentic Units) kernel: bootstrap loading, working memory, and structured notes.
-
-## Status
-
-Under development. See [tau-platform](https://github.com/tailored-agentic-units/tau-platform) for ecosystem coordination and concept documents.
+Context composition pipeline for the TAU (Tailored Agentic Units) kernel: persistent memory, skills, and agent profiles through a hierarchical key-value namespace with session-scoped caching and progressive loading.

--- a/memory/cache.go
+++ b/memory/cache.go
@@ -1,0 +1,205 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Cache provides session-scoped access to the memory namespace. It maintains
+// an index of all available keys and progressively loads content on demand.
+// Reads never trigger I/O. All methods are safe for concurrent use.
+type Cache struct {
+	store   Store
+	cache   map[string][]byte
+	index   map[string]bool
+	dirty   map[string]bool
+	removed map[string]bool
+	mu      sync.RWMutex
+}
+
+// NewCache creates a Cache backed by the given Store.
+func NewCache(store Store) *Cache {
+	return &Cache{
+		store:   store,
+		cache:   make(map[string][]byte),
+		index:   make(map[string]bool),
+		dirty:   make(map[string]bool),
+		removed: make(map[string]bool),
+	}
+}
+
+func (c *Cache) Bootstrap(ctx context.Context, prefixes ...string) error {
+	keys, err := c.store.List(ctx)
+	if err != nil {
+		return fmt.Errorf("bootstrap index: %w", err)
+	}
+
+	c.mu.Lock()
+	for _, key := range keys {
+		c.index[key] = true
+	}
+	c.mu.Unlock()
+
+	if len(prefixes) == 0 {
+		return nil
+	}
+
+	var toLoad []string
+	for _, key := range keys {
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(key, prefix) {
+				toLoad = append(toLoad, key)
+				break
+			}
+		}
+	}
+
+	if len(toLoad) == 0 {
+		return nil
+	}
+
+	entries, err := c.store.Load(ctx, toLoad...)
+	if err != nil {
+		return fmt.Errorf("bootstrap load: %w", err)
+	}
+
+	c.mu.Lock()
+	for _, e := range entries {
+		c.cache[e.Key] = e.Value
+	}
+	c.mu.Unlock()
+
+	return nil
+}
+
+func (c *Cache) Resolve(ctx context.Context, keys ...string) error {
+	c.mu.RLock()
+	var toLoad []string
+	for _, key := range keys {
+		if _, cached := c.cache[key]; !cached {
+			toLoad = append(toLoad, key)
+		}
+	}
+	c.mu.RUnlock()
+
+	if len(toLoad) == 0 {
+		return nil
+	}
+
+	entries, err := c.store.Load(ctx, toLoad...)
+	if err != nil {
+		return fmt.Errorf("resolve: %w", err)
+	}
+
+	c.mu.Lock()
+	for _, e := range entries {
+		c.cache[e.Key] = e.Value
+		c.index[e.Key] = true
+	}
+	c.mu.Unlock()
+
+	return nil
+}
+
+func (c *Cache) Flush(ctx context.Context) error {
+	c.mu.RLock()
+	var toSave []Entry
+	for key := range c.dirty {
+		if val, ok := c.cache[key]; ok {
+			toSave = append(toSave, Entry{Key: key, Value: val})
+		}
+	}
+	var toDelete []string
+	for key := range c.removed {
+		toDelete = append(toDelete, key)
+	}
+	c.mu.RUnlock()
+
+	if len(toSave) > 0 {
+		if err := c.store.Save(ctx, toSave...); err != nil {
+			return fmt.Errorf("flush save: %w", err)
+		}
+	}
+
+	if len(toDelete) > 0 {
+		if err := c.store.Delete(ctx, toDelete...); err != nil {
+			return fmt.Errorf("flush delete: %w", err)
+		}
+	}
+
+	c.mu.Lock()
+	c.dirty = make(map[string]bool)
+	c.removed = make(map[string]bool)
+	c.mu.Unlock()
+
+	return nil
+}
+
+func (c *Cache) Get(key string) ([]byte, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	val, ok := c.cache[key]
+	if !ok {
+		return nil, false
+	}
+	return slices.Clone(val), true
+}
+
+func (c *Cache) Set(key string, value []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cache[key] = slices.Clone(value)
+	c.index[key] = true
+	c.dirty[key] = true
+	delete(c.removed, key)
+}
+
+func (c *Cache) Delete(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	delete(c.cache, key)
+	delete(c.index, key)
+	delete(c.dirty, key)
+	c.removed[key] = true
+}
+
+func (c *Cache) Has(key string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.index[key]
+}
+
+func (c *Cache) Keys() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	keys := make([]string, 0, len(c.index))
+	for key := range c.index {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (c *Cache) Entries(prefix string) []Entry {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	var entries []Entry
+	for key, val := range c.cache {
+		if strings.HasPrefix(key, prefix) {
+			entries = append(entries, Entry{Key: key, Value: slices.Clone(val)})
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Key < entries[j].Key
+	})
+	return entries
+}

--- a/memory/cache_test.go
+++ b/memory/cache_test.go
@@ -1,0 +1,431 @@
+package memory_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/tailored-agentic-units/kernel/memory"
+)
+
+func TestCache_Bootstrap_IndexOnly(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	writeTestFile(t, root, "memory/global.md", "notes")
+	writeTestFile(t, root, "skills/a/SKILL.md", "skill")
+
+	cache := memory.NewCache(store)
+	if err := cache.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap() error = %v", err)
+	}
+
+	// Index populated
+	if !cache.Has("memory/global.md") {
+		t.Error("Has(memory/global.md) = false, want true")
+	}
+	if !cache.Has("skills/a/SKILL.md") {
+		t.Error("Has(skills/a/SKILL.md) = false, want true")
+	}
+
+	// Content not loaded
+	if _, ok := cache.Get("memory/global.md"); ok {
+		t.Error("Get(memory/global.md) should return false before Resolve")
+	}
+}
+
+func TestCache_Bootstrap_WithPrefixes(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	writeTestFile(t, root, "memory/global.md", "notes")
+	writeTestFile(t, root, "skills/a/SKILL.md", "skill")
+
+	cache := memory.NewCache(store)
+	if err := cache.Bootstrap(context.Background(), "memory/"); err != nil {
+		t.Fatalf("Bootstrap() error = %v", err)
+	}
+
+	// memory/ prefix loaded
+	val, ok := cache.Get("memory/global.md")
+	if !ok {
+		t.Fatal("Get(memory/global.md) = false, want true after Bootstrap with prefix")
+	}
+	if string(val) != "notes" {
+		t.Errorf("Get(memory/global.md) = %q, want %q", string(val), "notes")
+	}
+
+	// skills/ not loaded (not in prefix)
+	if _, ok := cache.Get("skills/a/SKILL.md"); ok {
+		t.Error("Get(skills/a/SKILL.md) should return false, not in bootstrap prefix")
+	}
+
+	// But indexed
+	if !cache.Has("skills/a/SKILL.md") {
+		t.Error("Has(skills/a/SKILL.md) = false, want true")
+	}
+}
+
+func TestCache_Bootstrap_EmptyStore(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+
+	cache := memory.NewCache(store)
+	if err := cache.Bootstrap(context.Background(), "memory/"); err != nil {
+		t.Fatalf("Bootstrap() error = %v", err)
+	}
+
+	if len(cache.Keys()) != 0 {
+		t.Errorf("Keys() returned %d keys, want 0", len(cache.Keys()))
+	}
+}
+
+func TestCache_Resolve(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	writeTestFile(t, root, "skills/a/SKILL.md", "skill content")
+
+	cache := memory.NewCache(store)
+	if err := cache.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap() error = %v", err)
+	}
+
+	// Not yet loaded
+	if _, ok := cache.Get("skills/a/SKILL.md"); ok {
+		t.Fatal("Get() should return false before Resolve")
+	}
+
+	// Resolve
+	if err := cache.Resolve(context.Background(), "skills/a/SKILL.md"); err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	val, ok := cache.Get("skills/a/SKILL.md")
+	if !ok {
+		t.Fatal("Get() should return true after Resolve")
+	}
+	if string(val) != "skill content" {
+		t.Errorf("Get() = %q, want %q", string(val), "skill content")
+	}
+}
+
+func TestCache_Resolve_SkipsCached(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	writeTestFile(t, root, "memory/global.md", "original")
+
+	cache := memory.NewCache(store)
+	if err := cache.Bootstrap(context.Background(), "memory/"); err != nil {
+		t.Fatalf("Bootstrap() error = %v", err)
+	}
+
+	// Modify the underlying file
+	writeTestFile(t, root, "memory/global.md", "modified")
+
+	// Resolve should skip already-cached key
+	if err := cache.Resolve(context.Background(), "memory/global.md"); err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	val, _ := cache.Get("memory/global.md")
+	if string(val) != "original" {
+		t.Errorf("Resolve should skip cached, got %q, want %q", string(val), "original")
+	}
+}
+
+func TestCache_Set_And_Get(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	cache := memory.NewCache(store)
+
+	cache.Set("memory/session.md", []byte("session notes"))
+
+	val, ok := cache.Get("memory/session.md")
+	if !ok {
+		t.Fatal("Get() should return true after Set")
+	}
+	if string(val) != "session notes" {
+		t.Errorf("Get() = %q, want %q", string(val), "session notes")
+	}
+
+	// Should also be in index
+	if !cache.Has("memory/session.md") {
+		t.Error("Has() should return true after Set")
+	}
+}
+
+func TestCache_Get_DefensiveCopy(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	cache := memory.NewCache(store)
+
+	cache.Set("key", []byte("original"))
+
+	val, _ := cache.Get("key")
+	val[0] = 'X'
+
+	got, _ := cache.Get("key")
+	if string(got) != "original" {
+		t.Errorf("Get() returned mutable reference, got %q after mutation", string(got))
+	}
+}
+
+func TestCache_Set_DefensiveCopy(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	cache := memory.NewCache(store)
+
+	input := []byte("original")
+	cache.Set("key", input)
+	input[0] = 'X'
+
+	val, _ := cache.Get("key")
+	if string(val) != "original" {
+		t.Errorf("Set() did not copy input, got %q after mutation", string(val))
+	}
+}
+
+func TestCache_Delete(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	cache := memory.NewCache(store)
+
+	cache.Set("key", []byte("value"))
+	cache.Delete("key")
+
+	if _, ok := cache.Get("key"); ok {
+		t.Error("Get() should return false after Delete")
+	}
+	if cache.Has("key") {
+		t.Error("Has() should return false after Delete")
+	}
+}
+
+func TestCache_Keys(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	writeTestFile(t, root, "b.md", "b")
+	writeTestFile(t, root, "a.md", "a")
+	writeTestFile(t, root, "c.md", "c")
+
+	cache := memory.NewCache(store)
+	if err := cache.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap() error = %v", err)
+	}
+
+	keys := cache.Keys()
+	want := []string{"a.md", "b.md", "c.md"}
+	if len(keys) != len(want) {
+		t.Fatalf("Keys() returned %d keys, want %d", len(keys), len(want))
+	}
+	for i, key := range keys {
+		if key != want[i] {
+			t.Errorf("Keys()[%d] = %q, want %q", i, key, want[i])
+		}
+	}
+}
+
+func TestCache_Entries(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	writeTestFile(t, root, "memory/a.md", "a")
+	writeTestFile(t, root, "memory/b.md", "b")
+	writeTestFile(t, root, "skills/x/SKILL.md", "x")
+
+	cache := memory.NewCache(store)
+	if err := cache.Bootstrap(context.Background(), "memory/", "skills/"); err != nil {
+		t.Fatalf("Bootstrap() error = %v", err)
+	}
+
+	entries := cache.Entries("memory/")
+	if len(entries) != 2 {
+		t.Fatalf("Entries(memory/) returned %d entries, want 2", len(entries))
+	}
+	if entries[0].Key != "memory/a.md" {
+		t.Errorf("entries[0].Key = %q, want %q", entries[0].Key, "memory/a.md")
+	}
+	if entries[1].Key != "memory/b.md" {
+		t.Errorf("entries[1].Key = %q, want %q", entries[1].Key, "memory/b.md")
+	}
+}
+
+func TestCache_Entries_OnlyCached(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	writeTestFile(t, root, "memory/a.md", "a")
+
+	cache := memory.NewCache(store)
+	if err := cache.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap() error = %v", err)
+	}
+
+	// Indexed but not loaded — should not appear in Entries
+	entries := cache.Entries("memory/")
+	if len(entries) != 0 {
+		t.Errorf("Entries() returned %d entries for unloaded prefix, want 0", len(entries))
+	}
+}
+
+func TestCache_Flush(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	cache := memory.NewCache(store)
+
+	cache.Set("memory/new.md", []byte("new content"))
+
+	if err := cache.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	// Verify persisted to store
+	entries, err := store.Load(context.Background(), "memory/new.md")
+	if err != nil {
+		t.Fatalf("Store.Load() error = %v", err)
+	}
+	if string(entries[0].Value) != "new content" {
+		t.Errorf("persisted value = %q, want %q", string(entries[0].Value), "new content")
+	}
+}
+
+func TestCache_Flush_DeletesRemoved(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	writeTestFile(t, root, "memory/old.md", "old")
+
+	cache := memory.NewCache(store)
+	if err := cache.Bootstrap(context.Background(), "memory/"); err != nil {
+		t.Fatalf("Bootstrap() error = %v", err)
+	}
+
+	cache.Delete("memory/old.md")
+
+	if err := cache.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	// Verify removed from store
+	_, err := store.Load(context.Background(), "memory/old.md")
+	if err == nil {
+		t.Error("Store.Load() should error after flushing deleted key")
+	}
+}
+
+func TestCache_Flush_OnlyDirty(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	writeTestFile(t, root, "memory/existing.md", "original")
+
+	cache := memory.NewCache(store)
+	if err := cache.Bootstrap(context.Background(), "memory/"); err != nil {
+		t.Fatalf("Bootstrap() error = %v", err)
+	}
+
+	// Flush without modifications
+	if err := cache.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	// Original file untouched
+	entries, err := store.Load(context.Background(), "memory/existing.md")
+	if err != nil {
+		t.Fatalf("Store.Load() error = %v", err)
+	}
+	if string(entries[0].Value) != "original" {
+		t.Errorf("value = %q, want %q", string(entries[0].Value), "original")
+	}
+}
+
+func TestCache_Flush_ClearsDirtyTracking(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	cache := memory.NewCache(store)
+
+	cache.Set("key", []byte("v1"))
+	if err := cache.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	// Modify the file directly on disk
+	writeTestFile(t, root, "key", "v2-on-disk")
+
+	// Second flush should not re-save the key (dirty tracking was cleared)
+	if err := cache.Flush(context.Background()); err != nil {
+		t.Fatalf("second Flush() error = %v", err)
+	}
+
+	entries, err := store.Load(context.Background(), "key")
+	if err != nil {
+		t.Fatalf("Store.Load() error = %v", err)
+	}
+	if string(entries[0].Value) != "v2-on-disk" {
+		t.Errorf("second flush overwrote file, got %q, want %q", string(entries[0].Value), "v2-on-disk")
+	}
+}
+
+func TestCache_Concurrent_GetSet(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	cache := memory.NewCache(store)
+	const n = 100
+
+	var wg sync.WaitGroup
+	wg.Add(2 * n)
+
+	for range n {
+		go func() {
+			defer wg.Done()
+			cache.Set("key", []byte("value"))
+		}()
+		go func() {
+			defer wg.Done()
+			cache.Get("key")
+		}()
+	}
+	wg.Wait()
+}
+
+func TestCache_Concurrent_SetDelete(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	cache := memory.NewCache(store)
+	const n = 100
+
+	var wg sync.WaitGroup
+	wg.Add(2 * n)
+
+	for range n {
+		go func() {
+			defer wg.Done()
+			cache.Set("key", []byte("value"))
+		}()
+		go func() {
+			defer wg.Done()
+			cache.Delete("key")
+		}()
+	}
+	wg.Wait()
+}
+
+func TestCache_Concurrent_HasKeys(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+	cache := memory.NewCache(store)
+	const n = 100
+
+	var wg sync.WaitGroup
+	wg.Add(3 * n)
+
+	for range n {
+		go func() {
+			defer wg.Done()
+			cache.Set("key", []byte("value"))
+		}()
+		go func() {
+			defer wg.Done()
+			cache.Has("key")
+		}()
+		go func() {
+			defer wg.Done()
+			cache.Keys()
+		}()
+	}
+	wg.Wait()
+}

--- a/memory/entry.go
+++ b/memory/entry.go
@@ -1,0 +1,15 @@
+package memory
+
+// Top-level namespace conventions for the memory key hierarchy.
+const (
+	NamespaceMemory = "memory"
+	NamespaceSkills = "skills"
+	NamespaceAgents = "agents"
+)
+
+// Entry is a key-value pair in the memory namespace. Keys are /-separated
+// hierarchical paths and values are raw bytes.
+type Entry struct {
+	Key   string
+	Value []byte
+}

--- a/memory/errors.go
+++ b/memory/errors.go
@@ -1,0 +1,10 @@
+package memory
+
+import "errors"
+
+// Sentinel errors for store operations.
+var (
+	ErrKeyNotFound = errors.New("key not found")
+	ErrLoadFailed  = errors.New("load failed")
+	ErrSaveFailed  = errors.New("save failed")
+)

--- a/memory/filestore.go
+++ b/memory/filestore.go
@@ -1,0 +1,127 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type fileStore struct {
+	root string
+}
+
+// NewFileStore creates a Store backed by the filesystem. Keys map 1:1 to
+// relative file paths under root.
+func NewFileStore(root string) Store {
+	return &fileStore{root: root}
+}
+
+func (s *fileStore) List(_ context.Context) ([]string, error) {
+	var keys []string
+
+	err := filepath.WalkDir(s.root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) && path == s.root {
+				return fs.SkipAll
+			}
+			return err
+		}
+
+		if strings.HasPrefix(d.Name(), ".") {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(s.root, path)
+		if err != nil {
+			return err
+		}
+		keys = append(keys, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrLoadFailed, err)
+	}
+
+	return keys, nil
+}
+
+func (s *fileStore) Load(_ context.Context, keys ...string) ([]Entry, error) {
+	entries := make([]Entry, 0, len(keys))
+
+	for _, key := range keys {
+		path := filepath.Join(s.root, filepath.FromSlash(key))
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, fmt.Errorf("%w: %s", ErrKeyNotFound, key)
+			}
+			return nil, fmt.Errorf("%w: %s: %v", ErrLoadFailed, key, err)
+		}
+		entries = append(entries, Entry{Key: key, Value: data})
+	}
+
+	return entries, nil
+}
+
+func (s *fileStore) Save(_ context.Context, entries ...Entry) error {
+	for _, e := range entries {
+		path := filepath.Join(s.root, filepath.FromSlash(e.Key))
+
+		dir := filepath.Dir(path)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("%w: %s: %v", ErrSaveFailed, e.Key, err)
+		}
+
+		tmp, err := os.CreateTemp(dir, ".tmp-*")
+		if err != nil {
+			return fmt.Errorf("%w: %s: %v", ErrSaveFailed, e.Key, err)
+		}
+		tmpName := tmp.Name()
+
+		if _, err := tmp.Write(e.Value); err != nil {
+			tmp.Close()
+			os.Remove(tmpName)
+			return fmt.Errorf("%w: %s: %v", ErrSaveFailed, e.Key, err)
+		}
+		if err := tmp.Close(); err != nil {
+			os.Remove(tmpName)
+			return fmt.Errorf("%w: %s: %v", ErrSaveFailed, e.Key, err)
+		}
+
+		if err := os.Rename(tmpName, path); err != nil {
+			os.Remove(tmpName)
+			return fmt.Errorf("%w: %s: %v", ErrSaveFailed, e.Key, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *fileStore) Delete(_ context.Context, keys ...string) error {
+	for _, key := range keys {
+		path := filepath.Join(s.root, filepath.FromSlash(key))
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("delete failed: %s: %w", key, err)
+		}
+
+		dir := filepath.Dir(path)
+		for dir != s.root {
+			if err := os.Remove(dir); err != nil {
+				break
+			}
+			dir = filepath.Dir(dir)
+		}
+	}
+
+	return nil
+}

--- a/memory/filestore_test.go
+++ b/memory/filestore_test.go
@@ -1,0 +1,275 @@
+package memory_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tailored-agentic-units/kernel/memory"
+)
+
+func TestFileStore_List_EmptyDir(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+
+	keys, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(keys) != 0 {
+		t.Errorf("List() returned %d keys, want 0", len(keys))
+	}
+}
+
+func TestFileStore_List_MissingRoot(t *testing.T) {
+	store := memory.NewFileStore(filepath.Join(t.TempDir(), "nonexistent"))
+
+	keys, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(keys) != 0 {
+		t.Errorf("List() returned %d keys, want 0", len(keys))
+	}
+}
+
+func TestFileStore_List_PopulatedDir(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "memory/global.md", "global notes")
+	writeTestFile(t, root, "skills/go-patterns/SKILL.md", "skill def")
+	writeTestFile(t, root, "agents/explorer.json", "{}")
+
+	store := memory.NewFileStore(root)
+	keys, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	want := []string{
+		"agents/explorer.json",
+		"memory/global.md",
+		"skills/go-patterns/SKILL.md",
+	}
+	if len(keys) != len(want) {
+		t.Fatalf("List() returned %d keys, want %d", len(keys), len(want))
+	}
+	for i, key := range keys {
+		if key != want[i] {
+			t.Errorf("List()[%d] = %q, want %q", i, key, want[i])
+		}
+	}
+}
+
+func TestFileStore_List_SkipsHidden(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "visible.md", "content")
+	writeTestFile(t, root, ".hidden", "secret")
+	writeTestFile(t, root, ".hiddendir/file.md", "nested secret")
+
+	store := memory.NewFileStore(root)
+	keys, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("List() returned %d keys, want 1", len(keys))
+	}
+	if keys[0] != "visible.md" {
+		t.Errorf("List()[0] = %q, want %q", keys[0], "visible.md")
+	}
+}
+
+func TestFileStore_Load(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "memory/global.md", "global notes")
+	writeTestFile(t, root, "agents/explorer.json", `{"name":"explorer"}`)
+
+	store := memory.NewFileStore(root)
+
+	entries, err := store.Load(context.Background(), "memory/global.md", "agents/explorer.json")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("Load() returned %d entries, want 2", len(entries))
+	}
+
+	if entries[0].Key != "memory/global.md" {
+		t.Errorf("entries[0].Key = %q, want %q", entries[0].Key, "memory/global.md")
+	}
+	if string(entries[0].Value) != "global notes" {
+		t.Errorf("entries[0].Value = %q, want %q", string(entries[0].Value), "global notes")
+	}
+
+	if entries[1].Key != "agents/explorer.json" {
+		t.Errorf("entries[1].Key = %q, want %q", entries[1].Key, "agents/explorer.json")
+	}
+	if string(entries[1].Value) != `{"name":"explorer"}` {
+		t.Errorf("entries[1].Value = %q, want %q", string(entries[1].Value), `{"name":"explorer"}`)
+	}
+}
+
+func TestFileStore_Load_KeyNotFound(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+
+	_, err := store.Load(context.Background(), "nonexistent.md")
+	if !errors.Is(err, memory.ErrKeyNotFound) {
+		t.Errorf("Load() error = %v, want %v", err, memory.ErrKeyNotFound)
+	}
+}
+
+func TestFileStore_Save(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+
+	entries := []memory.Entry{
+		{Key: "memory/global.md", Value: []byte("global notes")},
+		{Key: "skills/go-patterns/SKILL.md", Value: []byte("skill def")},
+	}
+
+	if err := store.Save(context.Background(), entries...); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Verify files written
+	got, err := os.ReadFile(filepath.Join(root, "memory", "global.md"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != "global notes" {
+		t.Errorf("file content = %q, want %q", string(got), "global notes")
+	}
+
+	got, err = os.ReadFile(filepath.Join(root, "skills", "go-patterns", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != "skill def" {
+		t.Errorf("file content = %q, want %q", string(got), "skill def")
+	}
+}
+
+func TestFileStore_Save_Overwrite(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+
+	if err := store.Save(context.Background(), memory.Entry{Key: "note.md", Value: []byte("v1")}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	if err := store.Save(context.Background(), memory.Entry{Key: "note.md", Value: []byte("v2")}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(root, "note.md"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != "v2" {
+		t.Errorf("file content = %q, want %q", string(got), "v2")
+	}
+}
+
+func TestFileStore_Delete(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "memory/global.md", "content")
+
+	store := memory.NewFileStore(root)
+
+	if err := store.Delete(context.Background(), "memory/global.md"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(root, "memory", "global.md")); !os.IsNotExist(err) {
+		t.Error("file should not exist after Delete")
+	}
+
+	// Parent directory should be cleaned up
+	if _, err := os.Stat(filepath.Join(root, "memory")); !os.IsNotExist(err) {
+		t.Error("empty parent directory should be removed after Delete")
+	}
+}
+
+func TestFileStore_Delete_NonExistent(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+
+	if err := store.Delete(context.Background(), "nonexistent.md"); err != nil {
+		t.Errorf("Delete() error = %v, want nil for missing key", err)
+	}
+}
+
+func TestFileStore_Delete_PreservesParentWithSiblings(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "memory/a.md", "content a")
+	writeTestFile(t, root, "memory/b.md", "content b")
+
+	store := memory.NewFileStore(root)
+
+	if err := store.Delete(context.Background(), "memory/a.md"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	// Parent should still exist because b.md is there
+	if _, err := os.Stat(filepath.Join(root, "memory")); os.IsNotExist(err) {
+		t.Error("parent directory should be preserved when sibling files exist")
+	}
+}
+
+func TestFileStore_RoundTrip(t *testing.T) {
+	root := t.TempDir()
+	store := memory.NewFileStore(root)
+
+	original := []memory.Entry{
+		{Key: "memory/global.md", Value: []byte("global notes")},
+		{Key: "skills/go-patterns/SKILL.md", Value: []byte("skill definition")},
+		{Key: "agents/explorer.json", Value: []byte(`{"tools":["grep"]}`)},
+	}
+
+	if err := store.Save(context.Background(), original...); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	keys, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	loaded, err := store.Load(context.Background(), keys...)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if len(loaded) != len(original) {
+		t.Fatalf("Load() returned %d entries, want %d", len(loaded), len(original))
+	}
+
+	got := make(map[string]string, len(loaded))
+	for _, entry := range loaded {
+		got[entry.Key] = string(entry.Value)
+	}
+	for _, entry := range original {
+		val, ok := got[entry.Key]
+		if !ok {
+			t.Errorf("key %q not found in loaded entries", entry.Key)
+			continue
+		}
+		if val != string(entry.Value) {
+			t.Errorf("key %q: value = %q, want %q", entry.Key, val, string(entry.Value))
+		}
+	}
+}
+
+// writeTestFile creates a file with the given content under root.
+func writeTestFile(t *testing.T, root, key, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(key))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}

--- a/memory/store.go
+++ b/memory/store.go
@@ -1,0 +1,19 @@
+// Package memory provides the context composition pipeline for the TAU kernel.
+// It manages a hierarchical key-value namespace backed by pluggable storage,
+// with session-scoped caching and progressive loading.
+package memory
+
+import "context"
+
+// Store translates between external storage and the internal key-value namespace.
+// Implementations are stateless — they perform I/O on each call without caching.
+type Store interface {
+	// List returns all available keys in the store.
+	List(ctx context.Context) ([]string, error)
+	// Load retrieves entries for the specified keys.
+	Load(ctx context.Context, keys ...string) ([]Entry, error)
+	// Save persists entries to storage, creating or overwriting as needed.
+	Save(ctx context.Context, entries ...Entry) error
+	// Delete removes entries from storage. Missing keys are ignored.
+	Delete(ctx context.Context, keys ...string) error
+}

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,7 +1,0 @@
-# skills
-
-Progressive disclosure skill system for the TAU (Tailored Agentic Units) kernel: SKILL.md discovery, loading, and matching.
-
-## Status
-
-Under development. See [tau-platform](https://github.com/tailored-agentic-units/tau-platform) for ecosystem coordination and concept documents.


### PR DESCRIPTION
## Summary

Implements the memory subsystem as the unified context composition pipeline for the TAU kernel. The package provides a hierarchical key-value namespace with pluggable storage and session-scoped caching with progressive loading.

Closes #13

## Changes

- **Store interface** — stateless persistence abstraction with `List`, `Load`, `Save`, `Delete`
- **FileStore** — filesystem implementation mapping keys 1:1 to relative file paths, with atomic writes and hidden file filtering
- **Cache** — session-scoped cache with `Bootstrap` (index + prefix loading), `Resolve` (on-demand loading), `Flush` (dirty entry persistence)
- **Entry type** and namespace constants (`memory`, `skills`, `agents`)
- Consolidated `skills/` skeleton into memory as a namespace convention
- 31 tests, 88.2% coverage