### PR TITLE
Runnable kernel CLI with built-in tools

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,7 +14,7 @@ TAU (Tailored Agentic Units) kernel — agent runtime with integrated subsystems
 | Validate | `go vet ./...` |
 | Proto lint | `cd rpc && buf lint` |
 | Proto generate | `cd rpc && buf generate` |
-| Kernel (Ollama) | `go run cmd/kernel/main.go -config cmd/kernel/agent.ollama.qwen3.json -prompt "..."` |
+| Kernel (Ollama) | `go run ./cmd/kernel/ -config cmd/kernel/agent.ollama.qwen3.json -prompt "..."` |
 | Prompt (Ollama) | `go run cmd/prompt-agent/main.go -config cmd/prompt-agent/agent.ollama.qwen3.json -prompt "..." -stream` |
 | Ollama | `docker compose up -d` |
 

--- a/.claude/context/guides/.archive/15-runnable-kernel-cli.md
+++ b/.claude/context/guides/.archive/15-runnable-kernel-cli.md
@@ -1,0 +1,476 @@
+# 15 — Runnable Kernel CLI with Built-in Tools
+
+## Problem Context
+
+The `cmd/kernel/main.go` is a stub. All kernel subsystems (session, memory, tools, kernel loop) are complete. This task replaces the stub with a functional CLI that exercises the full agentic loop against a real LLM — providing runtime validation of the entire kernel stack.
+
+## Architecture Approach
+
+Two files in `cmd/kernel/`: a tools file that defines and registers built-in tools with the global registry, and a main file that wires config loading, tool registration, kernel creation, and formatted output. Follows the proven `cmd/prompt-agent/main.go` pattern for CLI structure.
+
+Built-in tools live in `cmd/kernel/` (not in the `tools/` library) because they're CLI demo tools, not part of the kernel's core API.
+
+A seed memory directory at `cmd/kernel/memory/` with an identity file exercises the full `buildSystemContent()` path — memory loading, system prompt composition — so every kernel subsystem is validated at runtime.
+
+## Implementation
+
+### Step 1: Support unlimited iterations in `kernel/kernel.go`
+
+Change the `Run` loop from `for iteration := range k.maxIterations` to a traditional for-loop that treats 0 as unlimited. The context cancellation provides the safety net.
+
+In `kernel/kernel.go`, replace the loop header at line 141:
+
+```go
+// before
+for iteration := range k.maxIterations {
+
+// after
+for iteration := 0; k.maxIterations == 0 || iteration < k.maxIterations; iteration++ {
+```
+
+Semantics:
+- **0** → run until the agent produces a final response (or context cancellation)
+- **N > 0** → bounded to N iterations, returns `ErrMaxIterations` if exhausted
+
+### Step 2: Create `cmd/kernel/tools.go`
+
+New file. Registers 3 built-in tools with the global `tools.Register`.
+
+```go
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/tailored-agentic-units/kernel/core/protocol"
+	"github.com/tailored-agentic-units/kernel/tools"
+)
+
+func registerBuiltinTools() {
+	must(tools.Register(protocol.Tool{
+		Name:        "datetime",
+		Description: "Returns the current date and time in RFC3339 format.",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+	}, handleDatetime))
+
+	must(tools.Register(protocol.Tool{
+		Name:        "read_file",
+		Description: "Reads the contents of a file at the given path.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Absolute or relative path to the file to read.",
+				},
+			},
+			"required": []string{"path"},
+		},
+	}, handleReadFile))
+
+	must(tools.Register(protocol.Tool{
+		Name:        "list_directory",
+		Description: "Lists files and directories at the given path.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Absolute or relative path to the directory to list.",
+				},
+			},
+			"required": []string{"path"},
+		},
+	}, handleListDirectory))
+}
+
+func must(err error) {
+	if err != nil {
+		panic(fmt.Sprintf("failed to register tool: %v", err))
+	}
+}
+
+func handleDatetime(_ context.Context, _ json.RawMessage) (tools.Result, error) {
+	return tools.Result{Content: time.Now().Format(time.RFC3339)}, nil
+}
+
+func handleReadFile(_ context.Context, raw json.RawMessage) (tools.Result, error) {
+	var args struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return tools.Result{Content: "invalid arguments: " + err.Error(), IsError: true}, nil
+	}
+	if args.Path == "" {
+		return tools.Result{Content: "path is required", IsError: true}, nil
+	}
+
+	data, err := os.ReadFile(args.Path)
+	if err != nil {
+		return tools.Result{Content: err.Error(), IsError: true}, nil
+	}
+	return tools.Result{Content: string(data)}, nil
+}
+
+func handleListDirectory(_ context.Context, raw json.RawMessage) (tools.Result, error) {
+	var args struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return tools.Result{Content: "invalid arguments: " + err.Error(), IsError: true}, nil
+	}
+	if args.Path == "" {
+		args.Path = "."
+	}
+
+	entries, err := os.ReadDir(args.Path)
+	if err != nil {
+		return tools.Result{Content: err.Error(), IsError: true}, nil
+	}
+
+	var b strings.Builder
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() {
+			name += "/"
+		}
+		b.WriteString(name)
+		b.WriteByte('\n')
+	}
+	return tools.Result{Content: b.String()}, nil
+}
+```
+
+### Step 3: Replace `cmd/kernel/main.go`
+
+Replace the stub with a functional CLI.
+
+```go
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+
+	"github.com/tailored-agentic-units/kernel/kernel"
+)
+
+func main() {
+	var (
+		configFile    = flag.String("config", "", "Path to kernel config JSON file (required)")
+		prompt        = flag.String("prompt", "", "Prompt to send to the agent (required)")
+		systemPrompt  = flag.String("system-prompt", "", "System prompt (overrides config)")
+		memoryPath    = flag.String("memory", "", "Path to memory directory (overrides config)")
+		maxIterations = flag.Int("max-iterations", -1, "Maximum loop iterations; 0 for unlimited (overrides config)")
+	)
+	flag.Parse()
+
+	if *configFile == "" || *prompt == "" {
+		fmt.Fprintln(os.Stderr, "Usage: kernel -config <file> -prompt <text>")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	cfg, err := kernel.LoadConfig(*configFile)
+	if err != nil {
+		log.Fatalf("Failed to load config: %v", err)
+	}
+
+	if *systemPrompt != "" {
+		cfg.SystemPrompt = *systemPrompt
+	}
+	if *memoryPath != "" {
+		cfg.Memory.Path = *memoryPath
+	}
+	if *maxIterations >= 0 {
+		cfg.MaxIterations = *maxIterations
+	}
+
+	registerBuiltinTools()
+
+	k, err := kernel.New(cfg)
+	if err != nil {
+		log.Fatalf("Failed to create kernel: %v", err)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	result, err := k.Run(ctx, *prompt)
+	if err != nil {
+		log.Fatalf("Kernel run failed: %v", err)
+	}
+
+	fmt.Printf("Response: %s\n", result.Response)
+
+	if len(result.ToolCalls) > 0 {
+		fmt.Println("\nTool Calls:")
+		for i, tc := range result.ToolCalls {
+			fmt.Printf("  [%d] %s(%s)\n", i+1, tc.Name, tc.Arguments)
+			if tc.IsError {
+				fmt.Printf("      error: %s\n", tc.Result)
+			} else if len(tc.Result) > 200 {
+				fmt.Printf("      → %s...\n", tc.Result[:200])
+			} else {
+				fmt.Printf("      → %s\n", tc.Result)
+			}
+		}
+	}
+
+	fmt.Printf("\nIterations: %d\n", result.Iterations)
+}
+```
+
+### Step 4: Create `cmd/kernel/memory/identity.md`
+
+New file. Seed memory content that augments the system prompt via the memory subsystem.
+
+```markdown
+# Kernel Agent
+
+You are a TAU kernel agent running locally. You have access to tools for interacting with the filesystem and checking the current time. When asked questions, use your tools to find accurate answers rather than guessing.
+```
+
+### Step 5: Update `cmd/kernel/agent.ollama.qwen3.json`
+
+Add the memory path so memory loads by default without requiring the `-memory` flag.
+
+Add to the existing config JSON (sibling of `"agent"`, `"max_iterations"`, `"system_prompt"`):
+
+```json
+"memory": {
+  "path": "cmd/kernel/memory"
+}
+```
+
+## Remediation
+
+Steps required to clear blockers discovered during implementation.
+
+### R1: Add `MarshalJSON` to `ToolCall` in `core/protocol/message.go`
+
+The `ToolCall` type has a custom `UnmarshalJSON` that flattens the nested API format (`{function: {name, arguments}}`) into flat fields (`{name, arguments}`). However, there is no corresponding `MarshalJSON` — so when assistant messages containing tool calls are replayed back to the provider, they serialize in the flat format, which Ollama's OpenAI-compatible endpoint rejects as invalid.
+
+Add a `MarshalJSON` method that produces the nested format with `type: "function"`:
+
+```go
+func (tc ToolCall) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ID       string `json:"id"`
+		Type     string `json:"type"`
+		Function struct {
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		} `json:"function"`
+	}{
+		ID:   tc.ID,
+		Type: "function",
+		Function: struct {
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		}{
+			Name:      tc.Name,
+			Arguments: tc.Arguments,
+		},
+	})
+}
+```
+
+This ensures round-trip fidelity: provider responses decode correctly via `UnmarshalJSON`, and replayed messages serialize correctly via `MarshalJSON`.
+
+### R2: Add `*slog.Logger` to `Kernel` with `WithLogger` option
+
+Add a `*slog.Logger` field to the `Kernel` struct in `kernel/kernel.go` with a discard logger as the default. Add a `WithLogger` functional option.
+
+```go
+// in imports
+"io"
+"log/slog"
+```
+
+Add field to `Kernel` struct:
+
+```go
+log *slog.Logger
+```
+
+Default in `New` (alongside other field initializations):
+
+```go
+log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+```
+
+Add functional option:
+
+```go
+func WithLogger(l *slog.Logger) Option {
+	return func(k *Kernel) { k.log = l }
+}
+```
+
+### R3: Add log points in `buildSystemContent` and `Run`
+
+In `buildSystemContent`, replace the entry iteration loop:
+
+```go
+// before
+for _, entry := range entries {
+	content += "\n\n" + string(entry.Value)
+}
+
+// after
+for _, entry := range entries {
+	k.log.Debug("memory loaded", "key", entry.Key, "bytes", len(entry.Value))
+	content += "\n\n" + string(entry.Value)
+}
+```
+
+In `Run`, the full method with log points integrated:
+
+```go
+func (k *Kernel) Run(ctx context.Context, prompt string) (*Result, error) {
+	k.session.AddMessage(
+		protocol.NewMessage(protocol.RoleUser, prompt),
+	)
+
+	result := &Result{}
+
+	systemContent, err := k.buildSystemContent(ctx)
+	if err != nil {
+		return result, err
+	}
+
+	k.log.Info("run started", "prompt_length", len(prompt), "max_iterations", k.maxIterations, "tools", len(k.tools.List()))
+
+	for iteration := 0; k.maxIterations == 0 || iteration < k.maxIterations; iteration++ {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+
+		k.log.Debug("iteration started", "iteration", iteration+1)
+
+		messages := k.buildMessages(systemContent)
+
+		resp, err := k.agent.Tools(ctx, messages, k.tools.List())
+		if err != nil {
+			return result, fmt.Errorf("agent call failed: %w", err)
+		}
+
+		if len(resp.Choices) == 0 {
+			return result, fmt.Errorf("agent returned empty response")
+		}
+
+		choice := resp.Choices[0]
+
+		if len(choice.Message.ToolCalls) == 0 {
+			k.session.AddMessage(protocol.Message{
+				Role:    protocol.RoleAssistant,
+				Content: choice.Message.Content,
+			})
+			result.Response = choice.Message.Content
+			result.Iterations = iteration + 1
+			k.log.Info("run complete", "iterations", iteration+1, "response_length", len(result.Response))
+			return result, nil
+		}
+
+		k.session.AddMessage(protocol.Message{
+			Role:      protocol.RoleAssistant,
+			Content:   choice.Message.Content,
+			ToolCalls: choice.Message.ToolCalls,
+		})
+
+		for _, tc := range choice.Message.ToolCalls {
+			k.log.Debug("tool call", "iteration", iteration+1, "name", tc.Name)
+
+			record := ToolCallRecord{
+				Iteration: iteration + 1,
+				ID:        tc.ID,
+				Name:      tc.Name,
+				Arguments: tc.Arguments,
+			}
+
+			toolResult, toolErr := k.tools.Execute(
+				ctx,
+				tc.Name,
+				json.RawMessage(tc.Arguments),
+			)
+
+			if toolErr != nil {
+				errContent := fmt.Sprintf("error: %s", toolErr)
+				k.session.AddMessage(protocol.Message{
+					Role:       protocol.RoleTool,
+					Content:    errContent,
+					ToolCallID: tc.ID,
+				})
+				record.Result = errContent
+				record.IsError = true
+			} else {
+				k.session.AddMessage(protocol.Message{
+					Role:       protocol.RoleTool,
+					Content:    toolResult.Content,
+					ToolCallID: tc.ID,
+				})
+				record.Result = toolResult.Content
+				record.IsError = toolResult.IsError
+			}
+
+			result.ToolCalls = append(result.ToolCalls, record)
+		}
+
+		result.Iterations = iteration + 1
+	}
+
+	k.log.Warn("max iterations reached", "iterations", k.maxIterations)
+	return result, ErrMaxIterations
+}
+```
+
+### R4: Add `-verbose` flag to CLI
+
+In `cmd/kernel/main.go`, add a `-verbose` flag that creates an `slog.Logger` writing to stderr at the appropriate level, and pass it via `kernel.WithLogger`.
+
+```go
+verbose = flag.Bool("verbose", false, "Enable verbose logging to stderr")
+```
+
+After flag parsing, before `kernel.New`:
+
+```go
+var logger *slog.Logger
+if *verbose {
+	logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+} else {
+	logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+}
+```
+
+Pass to kernel:
+
+```go
+k, err := kernel.New(cfg, kernel.WithLogger(logger))
+```
+
+## Validation Criteria
+
+- [ ] `go vet ./...` passes
+- [ ] `go test ./...` passes (existing tests unbroken)
+- [ ] `go run ./cmd/kernel/ -config cmd/kernel/agent.ollama.qwen3.json -prompt "What time is it?"` produces a response with tool call log
+- [ ] Built-in tools are registered and callable by the LLM
+- [ ] Output shows response text, tool call log, and iteration count
+- [ ] `-verbose` flag shows memory loading and iteration sequence on stderr

--- a/.claude/context/sessions/15-runnable-kernel-cli.md
+++ b/.claude/context/sessions/15-runnable-kernel-cli.md
@@ -1,0 +1,46 @@
+# 15 — Runnable Kernel CLI with Built-in Tools
+
+## Summary
+
+Replaced the `cmd/kernel/main.go` stub with a functional CLI entry point that exercises the full agentic loop against a real LLM. Added three built-in tools (datetime, read_file, list_directory), seed memory for system prompt composition, and structured logging via `slog`. Fixed a ToolCall serialization bug that blocked provider communication.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Built-in tools location | `cmd/kernel/` (not `tools/`) | CLI demo tools, not part of the kernel library API |
+| Memory seed directory | `cmd/kernel/memory/` | Co-located with config; exercises full memory → system prompt pipeline |
+| Unlimited iterations | `maxIterations=0` means run until done | Clean semantic; context cancellation provides safety net |
+| Logger interface | `*slog.Logger` via `WithLogger` option | Standard library, zero dependencies, supports future per-subsystem logging |
+| ToolCall MarshalJSON | Value receiver, nested format | Round-trip fidelity with UnmarshalJSON; value receiver works in all serialization contexts |
+| CLI max-iterations flag | Default -1 (sentinel) | Distinguishes "not provided" from "unlimited" (0) |
+
+## Files Modified
+
+- `cmd/kernel/main.go` — replaced stub with functional CLI
+- `cmd/kernel/tools.go` — built-in tool definitions and registration (new)
+- `cmd/kernel/memory/identity.md` — seed memory content (new)
+- `cmd/kernel/agent.ollama.qwen3.json` — added memory path
+- `kernel/kernel.go` — unlimited iterations, `WithLogger`, slog log points
+- `core/protocol/message.go` — `ToolCall.MarshalJSON` for nested API format
+- `core/protocol/protocol_test.go` — MarshalJSON and round-trip tests
+- `kernel/kernel_test.go` — unlimited iterations and WithLogger tests
+- `_project/README.md` — kernel status updated to Complete
+- `_project/objective.md` — issue #15 status updated to Closed
+- `.claude/CLAUDE.md` — fixed kernel run command
+- `.claude/skills/kernel-dev/SKILL.md` — added WithLogger to kernel exports
+- `README.md` — fixed kernel run command
+
+## Patterns Established
+
+- **Remediation convention**: Implementation guides gain a Remediation section (R1, R2, ...) between final step and Validation Criteria for blockers discovered during execution
+- **slog logger pattern**: Kernel accepts `*slog.Logger` via `WithLogger`; discard logger default; subsystems will follow this pattern (tracked in Objective #4)
+- **CLI flag sentinel**: Use -1 default for optional numeric overrides where 0 has semantic meaning
+
+## Validation Results
+
+- `go vet ./...` — clean
+- `go test ./...` — all pass
+- `go mod tidy` — no changes
+- Coverage: kernel.go Run 100%, message.go MarshalJSON 100%, kernel package 94.2%, protocol package 92.3%
+- Manual: CLI runs against Ollama/Qwen3 with tool calls, memory loading, and verbose logging

--- a/.claude/plans/dazzling-singing-abelson.md
+++ b/.claude/plans/dazzling-singing-abelson.md
@@ -1,0 +1,66 @@
+# Issue #15 — Runnable Kernel CLI with Built-in Tools
+
+## Context
+
+The `cmd/kernel/main.go` is a stub printing "kernel: under development". All kernel subsystems are complete (session, memory, tools, kernel loop). This task replaces the stub with a functional CLI that exercises the full agentic loop against a real LLM, providing runtime validation of the entire kernel stack.
+
+## Approach
+
+Two new/modified files in `cmd/kernel/`:
+
+### 1. `cmd/kernel/tools.go` — Built-in tool definitions and registration
+
+A `registerBuiltinTools()` function that registers 3 tools with the global `tools.Register`:
+
+| Tool | Args | Implementation |
+|------|------|----------------|
+| `datetime` | none | `time.Now().Format(time.RFC3339)` |
+| `read_file` | `{"path": "string"}` | `os.ReadFile(path)` |
+| `list_directory` | `{"path": "string"}` | `os.ReadDir(path)`, format as newline-separated names |
+
+Each tool defined as `protocol.Tool` with JSON Schema parameters. Handlers are `tools.Handler` functions.
+
+### 2. `cmd/kernel/main.go` — Functional CLI entry point
+
+Following the `cmd/prompt-agent/main.go` pattern:
+
+**Flags:**
+- `-config` (required) — path to config JSON
+- `-prompt` (required) — user prompt
+- `-system-prompt` — override config value
+- `-memory` — path to memory directory (override `memory.path`)
+- `-max-iterations` — override config value
+
+**Flow:**
+1. Parse flags, validate required
+2. `kernel.LoadConfig(configFile)`
+3. Apply flag overrides to loaded config
+4. `registerBuiltinTools()`
+5. `kernel.New(&cfg)` → `kernel.Run(ctx, prompt)`
+6. Print formatted output: response text, iteration count, tool call log
+
+**Output format:**
+```
+Response: <text>
+
+Tool Calls:
+  [1] datetime() → 2026-02-16T...
+  [2] read_file({"path":"go.mod"}) → module github.com/...
+
+Iterations: 3
+```
+
+### Files Modified
+
+- `cmd/kernel/main.go` — replace stub (existing)
+- `cmd/kernel/tools.go` — new file
+
+### Config File
+
+`cmd/kernel/agent.ollama.qwen3.json` already exists with correct Ollama/Qwen3 config. No changes needed.
+
+### Verification
+
+1. `go vet ./...` passes
+2. `go test ./...` passes (no new tests needed for CLI main — runtime validation is the test)
+3. Manual: `go run cmd/kernel/main.go -config cmd/kernel/agent.ollama.qwen3.json -prompt "What time is it?"` produces response with tool call log

--- a/.claude/skills/kernel-dev/SKILL.md
+++ b/.claude/skills/kernel-dev/SKILL.md
@@ -67,7 +67,7 @@ Dependencies only flow downward. Never import a higher-level package from a lowe
 | `memory` | Context composition pipeline | `Store`, `Cache`, `Entry`, `NewFileStore`, `NewCache` |
 | `tools` | Tool execution and registry | `Handler`, `Result`, `Register`, `Execute`, `List` |
 | `session` | Conversation management | `Session`, `NewMemorySession` |
-| `kernel` | Agent runtime loop | `Kernel`, `Config`, `Result`, `ToolExecutor` |
+| `kernel` | Agent runtime loop | `Kernel`, `Config`, `Result`, `ToolExecutor`, `WithLogger` |
 
 ## Extension Patterns
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.1.0-dev.1.15
+
+### kernel
+
+- Replace `cmd/kernel/main.go` stub with functional CLI entry point (#15)
+- Add built-in tools: `datetime`, `read_file`, `list_directory` (#15)
+- Add seed memory directory at `cmd/kernel/memory/` for system prompt composition (#15)
+- Support unlimited iterations when `maxIterations` is 0 (#15)
+- Add `WithLogger` option with `*slog.Logger` for runtime observability (#15)
+- Add structured log points in `Run` and `buildSystemContent` (#15)
+
+### core
+
+- Add `ToolCall.MarshalJSON` for nested LLM API format round-trip fidelity (#15)
+
 ## v0.1.0-dev.1.14
 
 ### kernel

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Proto definitions live in `rpc/proto/`, generated code in `rpc/gen/`.
 docker compose up -d
 
 # Run the kernel with a prompt
-go run cmd/kernel/main.go \
+go run ./cmd/kernel/ \
   -config cmd/kernel/agent.ollama.qwen3.json \
   -prompt "What time is it?"
 

--- a/_project/README.md
+++ b/_project/README.md
@@ -45,7 +45,7 @@ Extension ecosystem (external services connecting through the interface):
 | **tools** | Tool system: global registry with Register, Execute, List | core | Complete |
 | **session** | Conversation management: Session interface, in-memory implementation | core | Complete |
 | **mcp** | MCP client: transport abstraction, tool discovery, stdio/SSE | tools | Skeleton |
-| **kernel** | Agent runtime: agentic loop, config-driven initialization | all above | Runtime loop |
+| **kernel** | Agent runtime: agentic loop, config-driven initialization, CLI entry point | all above | Complete |
 
 ## Dependency Hierarchy
 

--- a/_project/objective.md
+++ b/_project/objective.md
@@ -15,7 +15,7 @@ Implement the agentic processing loop — the core observe/think/act/repeat cycl
 | 12 | Tool registry interface and execution | Closed |
 | 13 | Memory store interface and filesystem implementation | Closed |
 | 14 | Kernel runtime loop | Closed |
-| 15 | Runnable kernel CLI with built-in tools | Open |
+| 15 | Runnable kernel CLI with built-in tools | Closed |
 
 ## Architecture Decisions
 

--- a/cmd/kernel/agent.ollama.qwen3.json
+++ b/cmd/kernel/agent.ollama.qwen3.json
@@ -33,6 +33,9 @@
       }
     }
   },
+  "memory": {
+    "path": "cmd/kernel/memory"
+  },
   "max_iterations": 10,
   "system_prompt": "You are a helpful assistant. Use the available tools when they would help answer the user's question."
 }

--- a/cmd/kernel/main.go
+++ b/cmd/kernel/main.go
@@ -1,7 +1,90 @@
 package main
 
-import "fmt"
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"log/slog"
+	"os"
+	"os/signal"
+
+	"github.com/tailored-agentic-units/kernel/kernel"
+)
 
 func main() {
-	fmt.Println("kernel: under development")
+	var (
+		configFile    = flag.String("config", "", "Path to kernel config JSON file (required)")
+		prompt        = flag.String("prompt", "", "Prompt to send to the agent (required)")
+		systemPrompt  = flag.String("system-prompt", "", "System prmopt (overrides config)")
+		memoryPath    = flag.String("memory", "", "Path to memory directory (overrides config)")
+		maxIterations = flag.Int("max-iterations", -1, "Maximum loop iterations; 0 for unlimited (overrides config)")
+		verbose       = flag.Bool("verbose", false, "Enable verbose logging to stderr")
+	)
+	flag.Parse()
+
+	if *configFile == "" || *prompt == "" {
+		fmt.Fprintln(os.Stderr, "Usage: kernel -config <file> -prompt <text>")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	cfg, err := kernel.LoadConfig(*configFile)
+	if err != nil {
+		log.Fatalf("Failed to load config: %v", err)
+	}
+
+	if *systemPrompt != "" {
+		cfg.SystemPrompt = *systemPrompt
+	}
+	if *memoryPath != "" {
+		cfg.Memory.Path = *memoryPath
+	}
+	if *maxIterations >= 0 {
+		cfg.MaxIterations = *maxIterations
+	}
+
+	var logger *slog.Logger
+	if *verbose {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+	} else {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
+	}
+
+	registerBuiltinTools()
+
+	runtime, err := kernel.New(cfg, kernel.WithLogger(logger))
+	if err != nil {
+		log.Fatalf("Failed to create kernel runtime: %v", err)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	result, err := runtime.Run(ctx, *prompt)
+	if err != nil {
+		log.Fatalf("Kernel run failed: %v", err)
+	}
+
+	fmt.Printf("Response: %s\n", result.Response)
+
+	if len(result.ToolCalls) > 0 {
+		fmt.Println("\nTool Calls:")
+		for i, tc := range result.ToolCalls {
+			fmt.Printf("  [%d] %s(%s)\n", i+1, tc.Name, tc.Arguments)
+			if tc.IsError {
+				fmt.Printf("    error: %s\n", tc.Result)
+			} else if len(tc.Result) > 200 {
+				fmt.Printf("    -> %s...\n", tc.Result[:200])
+			} else {
+				fmt.Printf("    -> %s\n", tc.Result)
+			}
+		}
+	}
+
+	fmt.Printf("\nIterations: %d\n", result.Iterations)
 }

--- a/cmd/kernel/memory/identity.md
+++ b/cmd/kernel/memory/identity.md
@@ -1,0 +1,3 @@
+# Kernel Agent
+
+You are a TAU kernel agent running locally. You have access to tools for interacting with the filesystem and checking the current time. When asked questions, use your tools to find accurate answers rather than guessing.

--- a/cmd/kernel/tools.go
+++ b/cmd/kernel/tools.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/tailored-agentic-units/kernel/core/protocol"
+	"github.com/tailored-agentic-units/kernel/tools"
+)
+
+func registerBuiltinTools() {
+	must(tools.Register(protocol.Tool{
+		Name:        "datetime",
+		Description: "Returns the current date and time in RFC3339 format.",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+	}, handleDatetime))
+
+	must(tools.Register(protocol.Tool{
+		Name:        "read_file",
+		Description: "Reads the contents of a file at the given path.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Absolute or relative path to the file to read.",
+				},
+			},
+			"required": []string{"path"},
+		},
+	}, handleReadFile))
+
+	must(tools.Register(protocol.Tool{
+		Name:        "list_directory",
+		Description: "Lists files and directories at the given path.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Abssolute or relative path to the directory to list.",
+				},
+			},
+			"required": []string{"path"},
+		},
+	}, handleListDirectory))
+}
+
+func must(err error) {
+	if err != nil {
+		panic(fmt.Sprintf("failed to register tool: %v", err))
+	}
+}
+
+func handleDatetime(_ context.Context, _ json.RawMessage) (tools.Result, error) {
+	return tools.Result{Content: time.Now().Format(time.RFC3339)}, nil
+}
+
+func handleReadFile(_ context.Context, raw json.RawMessage) (tools.Result, error) {
+	var args struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return tools.Result{Content: "invalid arguments: " + err.Error(), IsError: true}, nil
+	}
+	if args.Path == "" {
+		return tools.Result{Content: "path is required", IsError: true}, nil
+	}
+
+	data, err := os.ReadFile(args.Path)
+	if err != nil {
+		return tools.Result{Content: err.Error(), IsError: true}, nil
+	}
+	return tools.Result{Content: string(data)}, nil
+}
+
+func handleListDirectory(_ context.Context, raw json.RawMessage) (tools.Result, error) {
+	var args struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return tools.Result{Content: "invalid arguments: " + err.Error(), IsError: true}, nil
+	}
+	if args.Path == "" {
+		args.Path = "."
+	}
+
+	entries, err := os.ReadDir(args.Path)
+	if err != nil {
+		return tools.Result{Content: err.Error(), IsError: true}, nil
+	}
+
+	var b strings.Builder
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() {
+			name += "/"
+		}
+		b.WriteString(name)
+		b.WriteByte('\n')
+	}
+	return tools.Result{Content: b.String()}, nil
+}

--- a/core/protocol/message.go
+++ b/core/protocol/message.go
@@ -22,6 +22,29 @@ type ToolCall struct {
 	Arguments string `json:"arguments"`
 }
 
+// MarshalJSON serializes to the nested LLM API format ({type, function: {name, arguments}})
+// ensuring round-trip fidelity with UnmarshalJSON for provider communication.
+func (tc ToolCall) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ID       string `json:"id"`
+		Type     string `json:"type"`
+		Function struct {
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		} `json:"function"`
+	}{
+		ID:   tc.ID,
+		Type: "function",
+		Function: struct {
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		}{
+			Name:      tc.Name,
+			Arguments: tc.Arguments,
+		},
+	})
+}
+
 // UnmarshalJSON handles both the nested LLM API format ({function: {name, arguments}})
 // and the flat kernel format ({name, arguments}). This allows provider responses to
 // decode directly into the canonical ToolCall type.


### PR DESCRIPTION
## Summary

Replace the `cmd/kernel/main.go` stub with a functional CLI entry point that exercises the full agentic loop against a real LLM. Validates the entire kernel stack: agent, session, memory, and tools subsystems working together.

Closes #15

## Changes

- **CLI entry point** (`cmd/kernel/main.go`) — flag parsing, config loading, kernel run, formatted output with `-verbose` logging
- **Built-in tools** (`cmd/kernel/tools.go`) — `datetime`, `read_file`, `list_directory` registered with global tool registry
- **Seed memory** (`cmd/kernel/memory/identity.md`) — exercises the full memory → system prompt composition pipeline
- **Unlimited iterations** (`kernel/kernel.go`) — `maxIterations=0` runs until final response or context cancellation
- **Structured logging** (`kernel/kernel.go`) — `WithLogger` option with `*slog.Logger`, log points in `Run` and `buildSystemContent`
- **ToolCall serialization fix** (`core/protocol/message.go`) — `MarshalJSON` produces nested API format for provider round-trip fidelity
- **Tests** — `MarshalJSON` nested format and round-trip, unlimited iterations, `WithLogger` log verification